### PR TITLE
Bug Fix for Tracking Link

### DIFF
--- a/Web/Web.Server/Controllers/v1/UserTrackedPinsController.cs
+++ b/Web/Web.Server/Controllers/v1/UserTrackedPinsController.cs
@@ -1,4 +1,3 @@
-using AutoMapper;
 using Microsoft.AspNetCore.Mvc;
 using Web.Server.DTOs;
 using Web.Server.Services;
@@ -19,6 +18,76 @@ namespace Web.Server.Controllers.v1
             _userTrackedPinService = userTrackedPinService;
             _logger = logger;
         }
+
+        /// <summary>
+        /// Updates the symbol for a tracked pin by unique tracked pin ID.
+        /// </summary>
+        [HttpPatch("{trackedPinId}/symbol")]
+        public async Task<ActionResult<MessageEnvelope<object>>> UpdateTrackedPinSymbol(int trackedPinId, [FromBody] UpdateTrackedPinSymbolRequestDTO request)
+        {
+            try
+            {
+                var userId = GetCurrentUserId();
+                if (!userId.HasValue)
+                {
+                    return BadRequest(new MessageEnvelope<object>(null!, new List<string> { "User not authenticated." }));
+                }
+                await _userTrackedPinService.UpdateSymbolAsync(userId.Value, trackedPinId, request.Symbol);
+                return Ok(new MessageEnvelope<object>(new { success = true }, new List<string>()));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error updating tracked pin symbol");
+                return StatusCode(500, new MessageEnvelope<object>(null!, new List<string> { "An error occurred while updating the symbol." }));
+            }
+        }
+
+        /// <summary>
+        /// Updates the last known beacon for a tracked pin by unique tracked pin ID.
+        /// </summary>
+        [HttpPatch("{trackedPinId}/location")]
+        public async Task<ActionResult<MessageEnvelope<object>>> UpdateTrackedPinLocation(int trackedPinId, [FromBody] UpdateTrackedPinLocationRequestDTO request)
+        {
+            try
+            {
+                var userId = GetCurrentUserId();
+                if (!userId.HasValue)
+                {
+                    return BadRequest(new MessageEnvelope<object>(null!, new List<string> { "User not authenticated." }));
+                }
+                await _userTrackedPinService.UpdateLocationAsync(userId.Value, trackedPinId, request.BeaconID, request.SubdivisionID, request.BeaconName);
+                return Ok(new MessageEnvelope<object>(new { success = true }, new List<string>()));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error updating tracked pin location");
+                return StatusCode(500, new MessageEnvelope<object>(null!, new List<string> { "An error occurred while updating the location." }));
+            }
+        }
+
+        /// <summary>
+        /// Removes a tracked pin by unique tracked pin ID.
+        /// </summary>
+        [HttpDelete("{trackedPinId}")]
+        public async Task<ActionResult<MessageEnvelope<object>>> RemoveTrackedPin(int trackedPinId)
+        {
+            try
+            {
+                var userId = GetCurrentUserId();
+                if (!userId.HasValue)
+                {
+                    return BadRequest(new MessageEnvelope<object>(null!, new List<string> { "User not authenticated." }));
+                }
+                await _userTrackedPinService.DeleteAsync(userId.Value, trackedPinId);
+                return Ok(new MessageEnvelope<object>(new { success = true }, new List<string>()));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error deleting tracked pin");
+                return StatusCode(500, new MessageEnvelope<object>(null!, new List<string> { "An error occurred while deleting the tracked pin." }));
+            }
+        }
+
 
         /// <summary>
         /// Gets all tracked pins for the current user.
@@ -72,7 +141,7 @@ namespace Web.Server.Controllers.v1
                     request.Symbol,
                     request.Color);
 
-                return CreatedAtAction(nameof(GetUserTrackedPins), new { userId = userId.Value }, 
+                return CreatedAtAction(nameof(GetUserTrackedPins), new { userId = userId.Value },
                     new MessageEnvelope<UserTrackedPinDTO>(trackedPin, new List<string>()));
             }
             catch (Exception ex)
@@ -85,74 +154,6 @@ namespace Web.Server.Controllers.v1
         /// <summary>
         /// Updates the symbol for a tracked pin.
         /// </summary>
-        [HttpPatch("{mapPinId}/symbol")]
-        public async Task<ActionResult<MessageEnvelope<object>>> UpdateTrackedPinSymbol(int mapPinId, [FromBody] UpdateTrackedPinSymbolRequestDTO request)
-        {
-            try
-            {
-                var userId = GetCurrentUserId();
-                if (!userId.HasValue)
-                {
-                    return BadRequest(new MessageEnvelope<object>(null!, new List<string> { "User not authenticated." }));
-                }
-
-                await _userTrackedPinService.UpdateSymbolAsync(userId.Value, mapPinId, request.Symbol);
-                return Ok(new MessageEnvelope<object>(new { success = true }, new List<string>()));
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error updating tracked pin symbol");
-                return StatusCode(500, new MessageEnvelope<object>(null!, new List<string> { "An error occurred while updating the symbol." }));
-            }
-        }
-
-        /// <summary>
-        /// Updates the last known beacon for a tracked pin.
-        /// </summary>
-        [HttpPatch("{mapPinId}/location")]
-        public async Task<ActionResult<MessageEnvelope<object>>> UpdateTrackedPinLocation(int mapPinId, [FromBody] UpdateTrackedPinLocationRequestDTO request)
-        {
-            try
-            {
-                var userId = GetCurrentUserId();
-                if (!userId.HasValue)
-                {
-                    return BadRequest(new MessageEnvelope<object>(null!, new List<string> { "User not authenticated." }));
-                }
-
-                await _userTrackedPinService.UpdateLocationAsync(userId.Value, mapPinId, request.BeaconID, request.SubdivisionID, request.BeaconName);
-                return Ok(new MessageEnvelope<object>(new { success = true }, new List<string>()));
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error updating tracked pin location");
-                return StatusCode(500, new MessageEnvelope<object>(null!, new List<string> { "An error occurred while updating the location." }));
-            }
-        }
-
-        /// <summary>
-        /// Removes a tracked pin for the current user.
-        /// </summary>
-        [HttpDelete("{mapPinId}")]
-        public async Task<ActionResult<MessageEnvelope<object>>> RemoveTrackedPin(int mapPinId)
-        {
-            try
-            {
-                var userId = GetCurrentUserId();
-                if (!userId.HasValue)
-                {
-                    return BadRequest(new MessageEnvelope<object>(null!, new List<string> { "User not authenticated." }));
-                }
-
-                await _userTrackedPinService.DeleteAsync(userId.Value, mapPinId);
-                return Ok(new MessageEnvelope<object>(new { success = true }, new List<string>()));
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error removing tracked pin");
-                return StatusCode(500, new MessageEnvelope<object>(null!, new List<string> { "An error occurred while removing the tracked pin." }));
-            }
-        }
 
         private int? GetCurrentUserId()
         {

--- a/Web/Web.Server/Services/IUserTrackedPinService.cs
+++ b/Web/Web.Server/Services/IUserTrackedPinService.cs
@@ -4,13 +4,10 @@ namespace Web.Server.Services
 {
     public interface IUserTrackedPinService
     {
-        Task<UserTrackedPinDTO?> GetByIdAsync(int id);
         Task<IEnumerable<UserTrackedPinDTO>> GetByUserIdAsync(int userId);
-        Task<UserTrackedPinDTO?> GetByUserAndMapPinAsync(int userId, int mapPinId);
         Task<UserTrackedPinDTO> AddAsync(int userId, int mapPinId, int? beaconId, int? subdivisionId, string? beaconName, string? symbol, string color);
         Task UpdateSymbolAsync(int userId, int mapPinId, string? symbol);
         Task UpdateLocationAsync(int userId, int mapPinId, int? beaconId, int? subdivisionId, string? beaconName);
         Task DeleteAsync(int userId, int mapPinId);
-        Task CleanupExpiredAsync();
     }
 }

--- a/Web/Web.Server/Services/UserTrackedPinService.cs
+++ b/Web/Web.Server/Services/UserTrackedPinService.cs
@@ -35,11 +35,7 @@ namespace Web.Server.Services
             _hubContext = hubContext;
         }
 
-        public async Task<UserTrackedPinDTO?> GetByIdAsync(int id)
-        {
-            var entity = await _repository.GetByIdAsync(id);
-            return entity != null ? _mapper.Map<UserTrackedPinDTO>(entity) : null;
-        }
+
 
         public async Task<IEnumerable<UserTrackedPinDTO>> GetByUserIdAsync(int userId)
         {
@@ -47,19 +43,10 @@ namespace Web.Server.Services
             return _mapper.Map<IEnumerable<UserTrackedPinDTO>>(entities);
         }
 
-        public async Task<UserTrackedPinDTO?> GetByUserAndMapPinAsync(int userId, int mapPinId)
-        {
-            var entity = await _repository.GetByUserAndMapPinAsync(userId, mapPinId);
-            return entity != null ? _mapper.Map<UserTrackedPinDTO>(entity) : null;
-        }
-
         public async Task<UserTrackedPinDTO> AddAsync(int userId, int mapPinId, int? beaconId, int? subdivisionId, string? beaconName, string? symbol, string color)
         {
             try
             {
-                var now = _timeProvider.UtcNow;
-                var expiresUtc = now.AddHours(TrackingDurationHours);
-
                 var trackedPin = new UserTrackedPin
                 {
                     UserId = userId,
@@ -68,9 +55,9 @@ namespace Web.Server.Services
                     SubdivisionID = subdivisionId,
                     Symbol = symbol,
                     Color = color,
-                    ExpiresUtc = expiresUtc,
-                    CreatedAt = now,
-                    LastUpdate = now
+                    ExpiresUtc = _timeProvider.UtcNow.AddHours(TrackingDurationHours),
+                    CreatedAt = _timeProvider.UtcNow,
+                    LastUpdate = _timeProvider.UtcNow
                 };
 
                 var result = await _repository.AddAsync(trackedPin);
@@ -176,19 +163,6 @@ namespace Web.Server.Services
             {
                 _logger.LogError(ex, "Error deleting tracked pin for user {UserId} and pin {MapPinId}", userId, mapPinId);
                 throw;
-            }
-        }
-
-        public async Task CleanupExpiredAsync()
-        {
-            try
-            {
-                await _repository.DeleteExpiredAsync();
-                _logger.LogDebug("Cleanup: Removed expired tracked pins");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error during cleanup of expired tracked pins");
             }
         }
 

--- a/Web/web.client/src/components/BeaconLabelPin.tsx
+++ b/Web/web.client/src/components/BeaconLabelPin.tsx
@@ -234,6 +234,7 @@ const BeaconLabelPin: React.FC<BeaconLabelPinProps> = ({
                 } else {
                     await updateTrackedPinSymbol(selectedTrainId, '');
                 }
+                // Optionally update parent state if needed
             } catch (error) {
                 console.error('Failed to save symbol:', error);
                 alert(`Failed to save symbol: ${error instanceof Error ? error.message : 'Unknown error'}`);
@@ -246,6 +247,7 @@ const BeaconLabelPin: React.FC<BeaconLabelPinProps> = ({
         if (selectedTrainId) {
             try {
                 await removeTrackedMapPin(selectedTrainId);
+                // Optionally update parent state if needed
             } catch (error) {
                 console.error('Failed to untrack train:', error);
                 alert(`Failed to untrack train: ${error instanceof Error ? error.message : 'Unknown error'}`);

--- a/Web/web.client/src/components/BeaconMarkers.tsx
+++ b/Web/web.client/src/components/BeaconMarkers.tsx
@@ -56,33 +56,31 @@ const BeaconMarkers: React.FC<BeaconMarkersProps> = ({
     // Detect beacons that are close together horizontally and assign horizontal shifts
     const beaconHorizontalShifts = useMemo(() => {
         const shifts = new Map<string, number>();
-        const LONGITUDE_THRESHOLD = 0.005;
-        
+        const LATITUDE_THRESHOLD = 0.05;
+
         for (let i = 0; i < uniqueBeaconPins.length; i++) {
             for (let j = i + 1; j < uniqueBeaconPins.length; j++) {
                 const b1 = uniqueBeaconPins[i];
                 const b2 = uniqueBeaconPins[j];
-                
-                // Check if same beacon location but different railroad
-                if (b1.beaconID === b2.beaconID && Math.abs(b1.longitude - b2.longitude) < LONGITUDE_THRESHOLD) {
+
+                // Check if same beacon (ID) and latitudes are close enough
+                if (b1.beaconID === b2.beaconID && Math.abs(b1.latitude - b2.latitude) < LATITUDE_THRESHOLD) {
                     const id1 = `${b1.beaconID}-${b1.railroadID}`;
                     const id2 = `${b2.beaconID}-${b2.railroadID}`;
-                    
-                    // Use railroadID for deterministic ordering
-                    const rr1 = String(b1.railroadID || '');
-                    const rr2 = String(b2.railroadID || '');
-                    
-                    if (rr1 < rr2) {
-                        shifts.set(id1, -50); // Shift left
-                        shifts.set(id2, 50);  // Shift right
+
+                    // Use longitude for deterministic ordering
+                    if (b1.longitude < b2.longitude) {
+                        // b1 is further west, b2 is further east
+                        shifts.set(id1, -50);  // b1: left-most, right-aligned label (triangle points up-left)
+                        shifts.set(id2, 50);   // b2: right-most, left-aligned label (triangle points up-right)
                     } else {
-                        shifts.set(id1, 50);  // Shift right
-                        shifts.set(id2, -50); // Shift left
+                        shifts.set(id1, 50);   // b1: right-most, left-aligned label (triangle points up-right)
+                        shifts.set(id2, -50);  // b2: left-most, right-aligned label (triangle points up-left)
                     }
                 }
             }
         }
-        
+
         return shifts;
     }, [uniqueBeaconPins]);
 

--- a/Web/web.client/src/components/TelemetryMarker.tsx
+++ b/Web/web.client/src/components/TelemetryMarker.tsx
@@ -124,7 +124,7 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
             if (isEditingTrack) {
                 await updateTrackedPinSymbol(String(pin.id), symbol);
             } else {
-                await addTrackedMapPin(String(pin.id), pin.beaconID, pin.subdivisionID, pin.beaconName, symbol || undefined, addressesForModal);
+                await addTrackedMapPin(String(pin.id), pin.beaconID, pin.subdivisionID, pin.beaconName, symbol || undefined);
             }
             await updateTrackedPinsFromApi();
             setModalOpen(false);

--- a/Web/web.client/src/services/trackedPins.ts
+++ b/Web/web.client/src/services/trackedPins.ts
@@ -1,3 +1,33 @@
+// --- New API helpers for tracked pin by unique ID ---
+export async function updateTrackedPinSymbol(trackedPinId: string, symbol: string) {
+    const headers = await getAuthHeader();
+    const response = await fetch(`${API_BASE}/${trackedPinId}/symbol`, {
+        method: 'PATCH',
+        headers,
+        body: JSON.stringify({ symbol })
+    });
+    if (!response.ok) {
+        const errorText = await response.text().catch(() => 'Unknown error');
+        throw new Error(`Failed to update tracked pin symbol by ID in API (${response.status} ${response.statusText}): ${errorText}`);
+    }
+    // Always refresh pins from backend after mutation
+    return await refreshTrackedPinsFromApi();
+}
+
+export async function removeTrackedMapPin(trackedPinId: string) {
+    const headers = await getAuthHeader();
+    const response = await fetch(`${API_BASE}/${trackedPinId}`, {
+        method: 'DELETE',
+        headers
+    });
+    if (!response.ok) {
+        const errorText = await response.text().catch(() => 'Unknown error');
+        throw new Error(`Failed to remove tracked pin by ID from API (${response.status} ${response.statusText}): ${errorText}`);
+    }
+    // Always refresh pins from backend after mutation
+    return await refreshTrackedPinsFromApi();
+}
+
 // Extend Window type to include mapPins
 declare global {
     interface Window {
@@ -154,7 +184,7 @@ export async function refreshTrackedPinsFromApi(): Promise<TrackedPin[]> {
     return getLocalTrackedPins();
 }
 
-export async function addTrackedMapPin(id: string, beaconID?: string, subdivisionID?: string, beaconName?: string, symbol?: string, addresses?: Array<{ id: string; source: string }>) {
+export async function addTrackedMapPin(id: string, beaconID?: string, subdivisionID?: string, beaconName?: string, symbol?: string) {
     const mapPinId = parseInt(id, 10);
     if (isNaN(mapPinId)) {
         console.error('Invalid map pin ID provided:', id);
@@ -185,68 +215,23 @@ export async function addTrackedMapPin(id: string, beaconID?: string, subdivisio
 
     // After API success, fetch latest from server and update local cache
     const pins = await refreshTrackedPinsFromApi();
-    // Patch: ensure addresses are present in localStorage for this pin
-    if (addresses && addresses.length > 0) {
-        const arr = getLocalTrackedPins();
-        const tracked = arr.find(item => item.id === id);
-        if (tracked) {
-            tracked.addresses = [...addresses];
-            saveLocalTrackedPins(arr);
-        }
-    }
     window.dispatchEvent(new Event('storage'));
     return pins;
 }
 
-export async function removeTrackedMapPin(id: string) {
-    const mapPinId = parseInt(id, 10);
-    if (isNaN(mapPinId)) {
-        console.error('Invalid map pin ID provided:', id);
-        throw new Error('An unexpected error occurred. Please try again.');
-    }
-
-    // Delete from API first
-    const headers = await getAuthHeader();
-    const response = await fetch(`${API_BASE}/${mapPinId}`, {
-        method: 'DELETE',
-        headers
-    });
-    if (!response.ok) {
-        const errorText = await response.text().catch(() => 'Unknown error');
-        throw new Error(`Failed to remove tracked pin from API (${response.status} ${response.statusText}): ${errorText}`);
-    }
-
-    // After API success, fetch latest from server and update local cache
-    await refreshTrackedPinsFromApi();
-    window.dispatchEvent(new Event('storage'));
-}
 
 export function getTrackedColor(id: string): string | undefined {
     const arr = getLocalTrackedPins();
     return arr.find(item => item.id === id)?.color;
 }
 
-export async function updateTrackedPinLocation(id: string, beaconID: string, subdivisionID: string, beaconName: string | undefined, addresses?: Array<{ id: string; source: string }>) {
-    const arr = getLocalTrackedPins();
-    const tracked = arr.find(item => item.id === id);
-    if (tracked) {
-        tracked.lastBeaconID = beaconID;
-        tracked.lastSubdivisionID = subdivisionID;
-        if (beaconName !== undefined) {
-            tracked.lastBeaconName = beaconName;
-        }
-        if (addresses !== undefined) {
-            tracked.addresses = addresses.length > 0 ? [...addresses] : undefined;
-        }
-        saveLocalTrackedPins(arr);
-    }
-
-    // Persist to API (best-effort, background)
+export async function updateTrackedPinLocation(id: string, beaconID: string, subdivisionID: string, beaconName: string | undefined) {
+    // Always persist to API, then refresh from backend
     const mapPinId = parseInt(id, 10);
     if (!Number.isFinite(mapPinId)) return;
     try {
         const headers = await getAuthHeader();
-        await fetch(`${API_BASE}/${mapPinId}/location`, {
+        let response = await fetch(`${API_BASE}/${mapPinId}/location`, {
             method: 'PATCH',
             headers,
             body: JSON.stringify({
@@ -255,39 +240,18 @@ export async function updateTrackedPinLocation(id: string, beaconID: string, sub
                 beaconName
             })
         });
+        if (!response.ok) {
+            const errorText = await response.text().catch(() => 'Unknown error');
+            throw new Error(`Failed to update tracked pin location in API (${response.status} ${response.statusText}): ${errorText}`);
+        }
+        return await refreshTrackedPinsFromApi();
     } catch (err) {
         // Swallow errors; location will refresh on next add/update
         console.warn('Failed to sync tracked pin location', err);
+        return getLocalTrackedPins();
     }
 }
 
-export async function updateTrackedPinSymbol(id: string, symbol: string) {
-    const mapPinId = parseInt(id, 10);
-    if (isNaN(mapPinId)) {
-        console.error('Invalid map pin ID provided:', id);
-        throw new Error('An unexpected error occurred. Please try again.');
-    }
-
-    // Update in API first
-    const headers = await getAuthHeader();
-    const response = await fetch(`${API_BASE}/${mapPinId}/symbol`, {
-        method: 'PATCH',
-        headers,
-        body: JSON.stringify({ symbol })
-    });
-    if (!response.ok) {
-        const errorText = await response.text().catch(() => 'Unknown error');
-        throw new Error(`Failed to update tracked pin symbol in API (${response.status} ${response.statusText}): ${errorText}`);
-    }
-
-    // Update local storage after API success
-    const arr = getLocalTrackedPins();
-    const tracked = arr.find(item => item.id === id);
-    if (tracked) {
-        tracked.symbol = symbol;
-        saveLocalTrackedPins(arr);
-    }
-}
 
 export function getTrackedPinSymbol(id: string): string | undefined {
     const arr = getLocalTrackedPins();

--- a/Web/web.client/src/views/RailMap.tsx
+++ b/Web/web.client/src/views/RailMap.tsx
@@ -113,7 +113,7 @@ const RailMap: React.FC = () => {
         const trackedPins = getTrackedMapPins();
         if (trackedPins.length === 0 || mapPins.length === 0) return;
         
-        let updated = false;
+        let updatePromises: Promise<any>[] = [];
         trackedPins.forEach(tracked => {
             const mapPin = mapPins.find(p => String(p.id) === String(tracked.id));
             if (mapPin && mapPin.beaconID && mapPin.subdivisionID) {
@@ -127,14 +127,15 @@ const RailMap: React.FC = () => {
                     tracked.addresses.some((a, idx) => a.id !== addresses[idx].id || a.source !== addresses[idx].source)
                 );
                 if (locationChanged || addressesChanged) {
-                    updateTrackedPinLocation(tracked.id, mapPin.beaconID, mapPin.subdivisionID, mapPin.beaconName, addresses);
-                    updated = true;
+                    updatePromises.push(updateTrackedPinLocation(tracked.id, mapPin.beaconID, mapPin.subdivisionID, mapPin.beaconName));
                 }
             }
         });
-        
-        if (updated) {
-            setTrackedPinsState(getTrackedMapPins());
+        if (updatePromises.length > 0) {
+            Promise.all(updatePromises).then((results) => {
+                // Use the latest result from the backend
+                setTrackedPinsState(results[results.length - 1] || getTrackedMapPins());
+            });
         }
     }, [mapPins]);
 
@@ -158,8 +159,8 @@ const RailMap: React.FC = () => {
                     tracked.addresses.some((a, idx) => a.id !== addresses[idx].id || a.source !== addresses[idx].source)
                 );
                 if (locationChanged || addressesChanged) {
-                    updateTrackedPinLocation(mapPin.id, mapPin.beaconID, mapPin.subdivisionID, mapPin.beaconName, addresses);
-                    setTrackedPinsState(getTrackedMapPins());
+                    updateTrackedPinLocation(mapPin.id, mapPin.beaconID, mapPin.subdivisionID, mapPin.beaconName)
+                        .then(pins => setTrackedPinsState(pins || getTrackedMapPins()));
                 }
             }
             


### PR DESCRIPTION
The hyperlink associated with a tracked train, below the "Last Train" label, occasionally failed to move with the train from beacon to beacon.  This code fix is an attempt to resolve that issue by ensuring the locally cached tracking data always refreshes itself with database data first.