### PR TITLE
Fix Amtraker parser for array-root responses

### DIFF
--- a/Web/Web.Server/Services/AmtrakerPassengerProviderClient.cs
+++ b/Web/Web.Server/Services/AmtrakerPassengerProviderClient.cs
@@ -60,10 +60,16 @@ namespace Web.Server.Services
             return snapshots;
         }
 
+        /// <summary>
+        /// Resolves the train snapshot array from an Amtraker payload.
+        /// Supports both historical object-root responses keyed by train number and array-root responses.
+        /// </summary>
         private bool TryGetTrainsElement(JsonElement rootElement, string trainNumber, out JsonElement trainsElement)
         {
             trainsElement = default;
 
+            // This shape guard exists to prevent JsonElement type exceptions when the provider
+            // returns a payload root that does not match our original object-root assumption.
             switch (rootElement.ValueKind)
             {
                 case JsonValueKind.Object:

--- a/Web/Web.Server/Services/AmtrakerPassengerProviderClient.cs
+++ b/Web/Web.Server/Services/AmtrakerPassengerProviderClient.cs
@@ -23,7 +23,7 @@ namespace Web.Server.Services
             await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
             using var document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
 
-            if (!document.RootElement.TryGetProperty(trainNumber, out var trainsElement) || trainsElement.ValueKind != JsonValueKind.Array || trainsElement.GetArrayLength() == 0)
+            if (!TryGetTrainsElement(document.RootElement, trainNumber, out var trainsElement) || trainsElement.GetArrayLength() == 0)
             {
                 _logger.LogDebug("No Amtraker train data returned for train number {TrainNumber}.", trainNumber);
                 return [];
@@ -58,6 +58,34 @@ namespace Web.Server.Services
             }
 
             return snapshots;
+        }
+
+        private bool TryGetTrainsElement(JsonElement rootElement, string trainNumber, out JsonElement trainsElement)
+        {
+            trainsElement = default;
+
+            switch (rootElement.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    if (!rootElement.TryGetProperty(trainNumber, out var trainBucket) || trainBucket.ValueKind != JsonValueKind.Array)
+                    {
+                        return false;
+                    }
+
+                    trainsElement = trainBucket;
+                    return true;
+
+                case JsonValueKind.Array:
+                    trainsElement = rootElement;
+                    return true;
+
+                default:
+                    _logger.LogWarning(
+                        "Amtraker response payload had unsupported root type {RootType} for train number {TrainNumber}.",
+                        rootElement.ValueKind,
+                        trainNumber);
+                    return false;
+            }
         }
 
         private static string? ReadString(JsonElement element, string propertyName)

--- a/Web/Web.ServerTests/Services/AmtrakerPassengerProviderClientTests.cs
+++ b/Web/Web.ServerTests/Services/AmtrakerPassengerProviderClientTests.cs
@@ -53,6 +53,60 @@ namespace Web.ServerTests.Services
 			Assert.AreEqual(expectedHeading, snapshot.Heading);
 		}
 
+		[TestMethod]
+		public async Task GetTrainsAsync_ReturnsSnapshots_WhenResponseRootIsArray()
+		{
+			const string trainNumber = "8";
+			var content = """
+				[
+				  {
+					"provider": "Amtrak",
+					"routeName": "Hiawatha",
+					"trainNum": "8",
+					"trainID": "8-A",
+					"heading": "N",
+					"lat": 43.1,
+					"lon": -88.1,
+					"velocity": 55,
+					"updatedAt": "2026-06-11T12:34:56Z"
+				  }
+				]
+				""";
+
+			using var httpClient = new HttpClient(new StaticJsonHttpMessageHandler(content))
+			{
+				BaseAddress = new Uri("https://example.test/")
+			};
+
+			var logger = new Mock<ILogger<AmtrakerPassengerProviderClient>>();
+			var client = new AmtrakerPassengerProviderClient(httpClient, logger.Object);
+
+			var snapshots = (await client.GetTrainsAsync(trainNumber, CancellationToken.None)).ToList();
+
+			Assert.AreEqual(1, snapshots.Count);
+			Assert.AreEqual("8-A", snapshots[0].TrainId);
+			Assert.AreEqual("Northbound", snapshots[0].Heading);
+		}
+
+		[TestMethod]
+		public async Task GetTrainsAsync_ReturnsEmpty_WhenResponseRootTypeIsUnexpected()
+		{
+			const string trainNumber = "8";
+			const string content = "\"unexpected\"";
+
+			using var httpClient = new HttpClient(new StaticJsonHttpMessageHandler(content))
+			{
+				BaseAddress = new Uri("https://example.test/")
+			};
+
+			var logger = new Mock<ILogger<AmtrakerPassengerProviderClient>>();
+			var client = new AmtrakerPassengerProviderClient(httpClient, logger.Object);
+
+			var snapshots = await client.GetTrainsAsync(trainNumber, CancellationToken.None);
+
+			Assert.AreEqual(0, snapshots.Count());
+		}
+
 		private sealed class StaticJsonHttpMessageHandler(string json) : HttpMessageHandler
 		{
 			private readonly string _json = json;


### PR DESCRIPTION
## Summary
- handle both object-root and array-root Amtraker response payloads in `AmtrakerPassengerProviderClient`
- avoid `System.InvalidOperationException` when payload root is not an object keyed by train number
- add regression tests for array-root payloads and unsupported root types

## Why
Production logs showed repeated exceptions from passenger polling due to schema variation in the provider response root shape.

## Validation
- `dotnet test Web/Web.ServerTests/Web.Server.Tests.csproj`
- Result: 140 passed, 1 skipped, 0 failed

Closes #39