### PR TITLE
Add Find Me map control below zoom buttons

### DIFF
--- a/Web/web.client/src/components/FindMeControl.tsx
+++ b/Web/web.client/src/components/FindMeControl.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useRef } from 'react';
+import L from 'leaflet';
+import type { Map as LeafletMap } from 'leaflet';
+
+interface FindMeControlProps {
+    mapRef: React.RefObject<LeafletMap | null>;
+    userLocation: { latitude: number; longitude: number } | null;
+}
+
+const FindMeControl: React.FC<FindMeControlProps> = ({ mapRef, userLocation }) => {
+    const controlRef = useRef<L.Control | null>(null);
+
+    useEffect(() => {
+        if (!mapRef.current) return;
+
+        const map = mapRef.current;
+
+        // Remove existing control if any
+        if (controlRef.current && map.hasLayer(controlRef.current as any)) {
+            map.removeControl(controlRef.current);
+        }
+
+        // Only create control if user location is available
+        if (!userLocation) {
+            return;
+        }
+
+        // Create custom control
+        const FindMeControlClass = L.Control.extend({
+            onAdd: (_map: LeafletMap) => {
+                const container = L.DomUtil.create('div', 'leaflet-bar leaflet-control find-me-control');
+                const button = L.DomUtil.create('button', 'find-me-button', container);
+                
+                // Add SVG icon
+                button.innerHTML = `
+                    <svg class="find-me-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <circle cx="12" cy="12" r="9" />
+                        <circle cx="12" cy="12" r="3" />
+                        <path d="M12 1v6M12 17v6M1 12h6M17 12h6" />
+                    </svg>
+                `;
+                
+                button.title = 'Center map on your location';
+                
+                // Prevent map interaction when clicking button
+                L.DomEvent.disableClickPropagation(button);
+                L.DomEvent.disableScrollPropagation(button);
+                
+                // Handle click
+                button.addEventListener('click', () => {
+                    if (userLocation && mapRef.current) {
+                        // Get zoom from localStorage or use default
+                        const savedMapState = JSON.parse(localStorage.getItem('mapState') || 'null');
+                        const zoomLevel = savedMapState?.zoom || 14;
+                        
+                        mapRef.current.setView(
+                            [userLocation.latitude, userLocation.longitude],
+                            zoomLevel
+                        );
+                    }
+                });
+                
+                return container;
+            }
+        });
+
+        const findMeControl = new FindMeControlClass({ position: 'topleft' });
+        findMeControl.addTo(map);
+        controlRef.current = findMeControl;
+
+        return () => {
+            if (controlRef.current && map.hasLayer(controlRef.current as any)) {
+                map.removeControl(controlRef.current);
+                controlRef.current = null;
+            }
+        };
+    }, [mapRef, userLocation]);
+
+    return null;
+};
+
+export default FindMeControl;

--- a/Web/web.client/src/components/FindMeControl.tsx
+++ b/Web/web.client/src/components/FindMeControl.tsx
@@ -9,6 +9,11 @@ interface FindMeControlProps {
 
 const FindMeControl: React.FC<FindMeControlProps> = ({ mapRef, userLocation }) => {
     const controlRef = useRef<L.Control | null>(null);
+    const userLocationRef = useRef<{ latitude: number; longitude: number } | null>(null);
+
+    useEffect(() => {
+        userLocationRef.current = userLocation;
+    }, [userLocation]);
 
     useEffect(() => {
         if (!mapRef.current) return;
@@ -16,12 +21,13 @@ const FindMeControl: React.FC<FindMeControlProps> = ({ mapRef, userLocation }) =
         const map = mapRef.current;
 
         // Remove existing control if any
-        if (controlRef.current && map.hasLayer(controlRef.current as any)) {
+        if (controlRef.current) {
             map.removeControl(controlRef.current);
+            controlRef.current = null;
         }
 
         // Only create control if user location is available
-        if (!userLocation) {
+        if (!userLocationRef.current) {
             return;
         }
 
@@ -29,7 +35,8 @@ const FindMeControl: React.FC<FindMeControlProps> = ({ mapRef, userLocation }) =
         const FindMeControlClass = L.Control.extend({
             onAdd: (_map: LeafletMap) => {
                 const container = L.DomUtil.create('div', 'leaflet-bar leaflet-control find-me-control');
-                const button = L.DomUtil.create('button', 'find-me-button', container);
+                const button = L.DomUtil.create('button', 'find-me-button', container) as HTMLButtonElement;
+                button.type = 'button';
                 
                 // Add SVG icon
                 button.innerHTML = `
@@ -48,13 +55,13 @@ const FindMeControl: React.FC<FindMeControlProps> = ({ mapRef, userLocation }) =
                 
                 // Handle click
                 button.addEventListener('click', () => {
-                    if (userLocation && mapRef.current) {
+                    if (userLocationRef.current && mapRef.current) {
                         // Get zoom from localStorage or use default
                         const savedMapState = JSON.parse(localStorage.getItem('mapState') || 'null');
                         const zoomLevel = savedMapState?.zoom || 14;
                         
                         mapRef.current.setView(
-                            [userLocation.latitude, userLocation.longitude],
+                            [userLocationRef.current.latitude, userLocationRef.current.longitude],
                             zoomLevel
                         );
                     }
@@ -69,12 +76,12 @@ const FindMeControl: React.FC<FindMeControlProps> = ({ mapRef, userLocation }) =
         controlRef.current = findMeControl;
 
         return () => {
-            if (controlRef.current && map.hasLayer(controlRef.current as any)) {
+            if (controlRef.current) {
                 map.removeControl(controlRef.current);
                 controlRef.current = null;
             }
         };
-    }, [mapRef, userLocation]);
+    }, [mapRef, !!userLocation]);
 
     return null;
 };

--- a/Web/web.client/src/components/UserLocationPin.tsx
+++ b/Web/web.client/src/components/UserLocationPin.tsx
@@ -1,47 +1,15 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { Circle, CircleMarker, Tooltip } from 'react-leaflet';
+import { useUserLocation } from '../hooks/useUserLocation';
 
 type UserLocationPinProps = {
     mapTheme: 'dark' | 'light';
 };
 
-type UserLocation = {
-    latitude: number;
-    longitude: number;
-    accuracy: number;
-};
-
 const USER_LOCATION_PANE = 'userLocationPane';
 
 const UserLocationPin: React.FC<UserLocationPinProps> = ({ mapTheme }) => {
-    const [location, setLocation] = useState<UserLocation | null>(null);
-
-    useEffect(() => {
-        if (!('geolocation' in navigator)) {
-            return;
-        }
-
-        const watchId = navigator.geolocation.watchPosition(
-            (position) => {
-                const { latitude, longitude, accuracy } = position.coords;
-                setLocation({ latitude, longitude, accuracy });
-            },
-            (error) => {
-                if (error.code !== error.PERMISSION_DENIED) {
-                    console.warn('User location update failed:', error.message);
-                }
-            },
-            {
-                enableHighAccuracy: true,
-                maximumAge: 5000,
-                timeout: 20000
-            }
-        );
-
-        return () => {
-            navigator.geolocation.clearWatch(watchId);
-        };
-    }, []);
+    const location = useUserLocation();
 
     const markerColor = useMemo(() => {
         return mapTheme === 'dark' ? '#7dd3fc' : '#0b5cad';

--- a/Web/web.client/src/hooks/useUserLocation.ts
+++ b/Web/web.client/src/hooks/useUserLocation.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+
+type UserLocation = {
+    latitude: number;
+    longitude: number;
+    accuracy: number;
+};
+
+/**
+ * Custom hook to manage user geolocation using watchPosition.
+ * Returns the current location or null if not available/permission denied.
+ */
+export function useUserLocation(): UserLocation | null {
+    const [location, setLocation] = useState<UserLocation | null>(null);
+
+    useEffect(() => {
+        if (!('geolocation' in navigator)) {
+            return;
+        }
+
+        const watchId = navigator.geolocation.watchPosition(
+            (position) => {
+                const { latitude, longitude, accuracy } = position.coords;
+                setLocation({ latitude, longitude, accuracy });
+            },
+            (error) => {
+                if (error.code !== error.PERMISSION_DENIED) {
+                    console.warn('User location update failed:', error.message);
+                }
+            },
+            {
+                enableHighAccuracy: true,
+                maximumAge: 5000,
+                timeout: 20000
+            }
+        );
+
+        return () => {
+            navigator.geolocation.clearWatch(watchId);
+        };
+    }, []);
+
+    return location;
+}

--- a/Web/web.client/src/index.css
+++ b/Web/web.client/src/index.css
@@ -239,6 +239,68 @@ body:has(.admin-layout) .app-footer {
   z-index: 600 !important;
 }
 
+/* ---------- Find Me Control ---------- */
+.find-me-control {
+  background-color: white;
+  border-radius: 4px;
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.65);
+  margin: 10px;
+  margin-top: 67px; /* Position below zoom controls */
+}
+
+.find-me-button {
+  width: 36px;
+  height: 36px;
+  background: white;
+  border: none;
+  color: #333;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  outline: none;
+  font-size: 16px;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.find-me-button:hover {
+  background-color: #f4f4f4;
+  color: #007bff;
+}
+
+.find-me-button:active {
+  background-color: #e8e8e8;
+  color: #0056b3;
+}
+
+.find-me-icon {
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+}
+
+/* Dark theme variant */
+.dark .find-me-control {
+  background-color: #222;
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.8);
+}
+
+.dark .find-me-button {
+  background: #222;
+  color: #ccc;
+}
+
+.dark .find-me-button:hover {
+  background-color: #2a2a2a;
+  color: #66b3ff;
+}
+
+.dark .find-me-button:active {
+  background-color: #1f1f1f;
+  color: #4d94ff;
+}
+
 /* ---------- Tracking Dot Pulse Animation ---------- */
 @keyframes pulse {
   0%, 100% {

--- a/Web/web.client/src/index.css
+++ b/Web/web.client/src/index.css
@@ -250,11 +250,11 @@ body:has(.admin-layout) .app-footer {
 
 .find-me-button {
   all: unset;
-  width: 36px;
-  height: 36px;
+  width: 30px;
+  height: 30px;
   background: transparent;
   border: none;
-  color: #333;
+  color: #000;
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -267,12 +267,12 @@ body:has(.admin-layout) .app-footer {
 
 .find-me-button:hover {
   background-color: #f4f4f4;
-  color: #007bff;
+  color: #000;
 }
 
 .find-me-button:active {
   background-color: #e8e8e8;
-  color: #0056b3;
+  color: #000;
 }
 
 .find-me-icon {
@@ -281,24 +281,9 @@ body:has(.admin-layout) .app-footer {
   stroke: currentColor;
 }
 
-/* Dark theme variant */
-.dark .find-me-control {
-  background-color: #222;
-  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.8);
-}
-
-.dark .find-me-button {
-  color: #ccc;
-}
-
-.dark .find-me-button:hover {
-  background-color: #2a2a2a;
-  color: #66b3ff;
-}
-
-.dark .find-me-button:active {
-  background-color: #1f1f1f;
-  color: #4d94ff;
+.leaflet-touch .find-me-button {
+  width: 30px;
+  height: 30px;
 }
 
 /* ---------- Tracking Dot Pulse Animation ---------- */

--- a/Web/web.client/src/index.css
+++ b/Web/web.client/src/index.css
@@ -249,9 +249,10 @@ body:has(.admin-layout) .app-footer {
 }
 
 .find-me-button {
+  all: unset;
   width: 36px;
   height: 36px;
-  background: white;
+  background: transparent;
   border: none;
   color: #333;
   cursor: pointer;
@@ -275,8 +276,8 @@ body:has(.admin-layout) .app-footer {
 }
 
 .find-me-icon {
-  width: 18px;
-  height: 18px;
+  width: 23px;
+  height: 23px;
   stroke: currentColor;
 }
 
@@ -287,7 +288,6 @@ body:has(.admin-layout) .app-footer {
 }
 
 .dark .find-me-button {
-  background: #222;
   color: #ccc;
 }
 

--- a/Web/web.client/src/views/RailMap.tsx
+++ b/Web/web.client/src/views/RailMap.tsx
@@ -9,6 +9,7 @@ import { LatLngTuple, Map as LeafletMap } from 'leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { useSignalR } from '../hooks/useSignalR';
+import { useUserLocation } from '../hooks/useUserLocation';
 import { Beacon } from '../types/Beacon';
 import { MapPin } from '../types/MapPin';
 import BeaconMarkers from '../components/BeaconMarkers';
@@ -17,6 +18,7 @@ import PassengerTelemetryMarkers from '../components/PassengerTelemetryMarkers';
 import MilepostLayer from '../components/MilepostLayer';
 import DefectDetectorLayer from '../components/DefectDetectorLayer';
 import UserLocationPin from '../components/UserLocationPin';
+import FindMeControl from '../components/FindMeControl';
 import { BeaconHistoryModal } from '../components/BeaconHistoryModal';
 import { getTrackedMapPins, updateTrackedPinLocation, refreshTrackedPinsFromApi, applyTrackedPinAddedOrUpdatedFromServer, applyTrackedPinRemovedFromServer, addTrackedMapPinByShareCode } from '../services/trackedPins';
 import { metersToLongitudeDegrees, pixelsToMeters } from '../utils/geo';
@@ -114,6 +116,7 @@ const RailMap: React.FC = () => {
     const [passengerMapPins, setPassengerMapPins] = useState<PassengerMapPin[]>([]);
     const { milepostPoints } = useMileposts();
     const { defectDetectors } = useDefectDetectors();
+    const userLocation = useUserLocation();
 
     // Track the current tracked pins in state to trigger re-renders when they change
     const [trackedPinsState, setTrackedPinsState] = useState(() => getTrackedMapPins());
@@ -953,6 +956,11 @@ const RailMap: React.FC = () => {
                 )}
 
                 <UserLocationPin mapTheme={mapTheme as 'dark' | 'light'} />
+                
+                <FindMeControl 
+                    mapRef={mapRef}
+                    userLocation={userLocation}
+                />
 
             </MapContainer>
 


### PR DESCRIPTION
## Summary
- Add a Find Me map control below Leaflet zoom controls
- Show the control only when geolocation is available
- Center the map on the current user location using cached zoom (fallback to 14)
- Align control visuals with zoom controls and fix duplicate render behavior

## Validation
- npm run build (Web/web.client)

Fixes #41