### PR TITLE
Fix admin map pin reset to delete stuck pin and update map immediately

### DIFF
--- a/Web/Web.Server/Controllers/v1/MapPinsController.cs
+++ b/Web/Web.Server/Controllers/v1/MapPinsController.cs
@@ -202,6 +202,45 @@ namespace Web.Server.Controllers.v1
             }
         }
 
+        // DELETE: api/v1/MapPins/5/addresses
+        [HttpDelete("{id}/addresses")]
+        public async Task<IActionResult> ClearAddresses(int id)
+        {
+            if (!await IsAdminAsync())
+            {
+                return StatusCode(StatusCodes.Status403Forbidden);
+            }
+
+            try
+            {
+                var success = await _mapPinsService.DeleteMapPinAsync(id);
+                if (!success)
+                {
+                    return NotFound();
+                }
+
+                _logger.LogInformation("Admin reset map pin {MapPinId} by deleting map pin and address list.", id);
+                return NoContent();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An error occurred while resetting map pin {MapPinId}.", id);
+                return StatusCode(StatusCodes.Status500InternalServerError, new { error = ex.Message });
+            }
+        }
+
+        private async Task<bool> IsAdminAsync()
+        {
+            if (!HttpContext.Items.TryGetValue("UserId", out var userIdObj) || userIdObj is not int userId)
+            {
+                return false;
+            }
+
+            var user = await _userService.GetUserByIdAsync(userId);
+            return user?.UserRoles?.Any(ur =>
+                string.Equals(ur.Role?.RoleName, "Admin", StringComparison.OrdinalIgnoreCase)) == true;
+        }
+
         private async Task<bool> CanViewSupportAddressesAsync()
         {
             if (!HttpContext.Items.TryGetValue("UserId", out var userIdObj) || userIdObj is not int userId)

--- a/Web/Web.Server/Repositories/MapPinRepository.cs
+++ b/Web/Web.Server/Repositories/MapPinRepository.cs
@@ -261,11 +261,19 @@ namespace Web.Server.Repositories
 
         public async Task<bool> DeleteAsync(int id)
         {
-            var mapPin = await _context.MapPins.FindAsync(id);
+            var mapPin = await _context.MapPins
+                .Include(mp => mp.Addresses)
+                .FirstOrDefaultAsync(mp => mp.ID == id);
             if (mapPin == null)
             {
                 return false;
             }
+
+            if (mapPin.Addresses.Count > 0)
+            {
+                _context.Addresses.RemoveRange(mapPin.Addresses);
+            }
+
             _context.MapPins.Remove(mapPin);
             await _context.SaveChangesAsync();
             return true;

--- a/Web/web.client/src/api/mapPinsApi.ts
+++ b/Web/web.client/src/api/mapPinsApi.ts
@@ -16,3 +16,21 @@ export const fetchInitialTelemetryPins = async (setMapPins: any) => {
     console.error('Error fetching map pins:', error);
   }
 };
+
+// Admin: reset a map pin by deleting the map pin and all address IDs
+export const deleteMapPinAddresses = async (id: number): Promise<void> => {
+  const { getAuthToken } = await import('../services/auth');
+  const token = await getAuthToken();
+  const apiUrl = `${import.meta.env.VITE_API_URL}/api/v1/MapPins/${id}/addresses`;
+  const response = await fetch(apiUrl, {
+    method: 'DELETE',
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      'X-Api-Key': import.meta.env.VITE_API_KEY,
+      'Content-Type': 'application/json'
+    }
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to reset map pin ${id}: ${response.status}`);
+  }
+};

--- a/Web/web.client/src/components/TelemetryMarker.tsx
+++ b/Web/web.client/src/components/TelemetryMarker.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { parseISO } from 'date-fns/parseISO';
 import { format } from 'date-fns';
 import { addTrackedMapPin, removeTrackedMapPin, getTrackedPinSymbol, updateTrackedPinSymbol, refreshTrackedPinsFromApi, copyTrackedPinShareUrl, buildTrackedPinShareUrl } from '../services/trackedPins';
+import { deleteMapPinAddresses } from '../api/mapPinsApi';
 // Extend window type for setTrackedPinsStateFromApi
 declare global {
     interface Window {
@@ -45,6 +46,8 @@ interface TelemetryMarkerProps {
     longitudeOffset?: number;
     hourFormat?: string;
     canViewSupportAddresses?: boolean;
+    isAdmin?: boolean;
+    onMapPinDeleted?: (id: number) => void;
 }
 
 const formatDirection = (dir?: string | null): string => {
@@ -68,7 +71,7 @@ const formatDirection = (dir?: string | null): string => {
     return map[dir.toUpperCase()] || 'Unknown Direction';
 };
 
-const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'light' }> = ({ pin, size, maxPinAgeMinutes, mapTheme, trackedPins, longitudeOffset = 0, hourFormat = '24', canViewSupportAddresses = false }) => {
+const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'light' }> = ({ pin, size, maxPinAgeMinutes, mapTheme, trackedPins, longitudeOffset = 0, hourFormat = '24', canViewSupportAddresses = false, isAdmin = false, onMapPinDeleted }) => {
     // hourFormat is destructured from props with default '24'
     // Inject dark mode popup CSS override once per page load
     useEffect(() => {
@@ -196,6 +199,7 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
         const trackTextId = `track-text-${pin.id}`;
         const shareTextId = `share-text-${pin.id}`;
         const shareStatusId = `share-status-${pin.id}`;
+        const resetAddressesId = `reset-addresses-${pin.id}`;
         const trackedPinForLabel =
             trackedPins.find(tp => String(tp.id) === String(pin.id)) ||
             (pin.shareCode ? trackedPins.find(tp => tp.shareCode === pin.shareCode) : undefined);
@@ -240,6 +244,7 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
                 ${addressLines}
                 ${pin.shareCode ? `<button id='${shareTextId}' type='button' title='Share link' style='cursor:pointer;display:inline-flex;align-items:center;gap:6px;padding:${actionRowPadding};margin-top:${isCoarsePointer ? '2px' : '0'};margin-bottom:6px;color:${mapTheme === 'dark' ? '#d5d9df' : '#4b5563'};background:none;border:none;font:inherit;text-align:left;line-height:inherit;'>${copyIcon}<span style='text-decoration:underline;'>Share</span><span id='${shareStatusId}' style='font-size:12px;opacity:0;transition:opacity 0.2s ease;'></span></button>` : ''}
                 ${pin.shareCode ? '' : `<span id='${trackTextId}' style='cursor:pointer;text-decoration:underline;display:inline-flex;align-items:center;gap:6px;padding:${actionRowPadding};'><span style='display:inline-flex;align-items:center;'>${trackingBadge}</span>${trackText}</span>`}
+                ${isAdmin && canViewSupportAddresses ? `<br/><button id='${resetAddressesId}' type='button' title='Admin: clear address ID list' style='cursor:pointer;display:inline-flex;align-items:center;gap:6px;padding:${actionRowPadding};margin-top:4px;color:#ef4444;background:none;border:none;font:inherit;text-align:left;line-height:inherit;font-size:0.85em;'>&#x26A0; Reset Addresses</button>` : ''}
             </div>
         `;
 
@@ -343,6 +348,20 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
                 updateShareStatus(false);
             }
         };
+        const handleResetAddressesClick = async (e: MouseEvent) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (!window.confirm(`Reset map pin (ID: ${pin.id})? This deletes the pin and all addresses immediately.`)) {
+                return;
+            }
+            try {
+                await deleteMapPinAddresses(Number(pin.id));
+                onMapPinDeleted?.(Number(pin.id));
+                marker.closePopup();
+            } catch (error) {
+                console.error('Failed to reset map pin:', error);
+            }
+        };
         const attachHandler = () => {
             trackTextEl = document.getElementById(trackTextId);
             if (trackTextEl) {
@@ -356,6 +375,14 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
                 L.DomEvent.disableScrollPropagation(shareTextEl);
                 shareTextEl.addEventListener('click', handleShareTextClick);
             }
+
+            if (isAdmin && canViewSupportAddresses) {
+                const resetEl = document.getElementById(resetAddressesId);
+                if (resetEl) {
+                    L.DomEvent.disableClickPropagation(resetEl);
+                    resetEl.addEventListener('click', handleResetAddressesClick);
+                }
+            }
         };
         const detachHandler = () => {
             if (trackTextEl) {
@@ -366,6 +393,11 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
             if (shareTextEl) {
                 shareTextEl.removeEventListener('click', handleShareTextClick);
                 shareTextEl = null;
+            }
+
+            const resetEl = document.getElementById(resetAddressesId);
+            if (resetEl) {
+                resetEl.removeEventListener('click', handleResetAddressesClick);
             }
         };
         const onPopupOpen = () => {
@@ -416,7 +448,7 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
                 clearTimeout(shareFeedbackTimeout);
             }
         };
-    }, [pin.id, pin.shareCode, pin.beaconID, pin.beaconName, pin.railroad, pin.subdivision, pin.milepost, pin.direction, pin.moving, pin.lastUpdate, pin.addresses, isTracked, trackColor, mapTheme, hourFormat]);
+    }, [pin.id, pin.shareCode, pin.beaconID, pin.beaconName, pin.railroad, pin.subdivision, pin.milepost, pin.direction, pin.moving, pin.lastUpdate, pin.addresses, isTracked, trackColor, mapTheme, hourFormat, isAdmin, canViewSupportAddresses, onMapPinDeleted]);
 
     // Use ArrowMapPin as the icon, with rotation and border color
     const createCustomIcon = () => {

--- a/Web/web.client/src/components/TelemetryMarkers.tsx
+++ b/Web/web.client/src/components/TelemetryMarkers.tsx
@@ -15,6 +15,8 @@ interface TelemetryMarkersProps {
     trackedPins: TrackedPin[];
     hourFormat?: string;
     canViewSupportAddresses?: boolean;
+    isAdmin?: boolean;
+    onMapPinDeleted?: (id: number) => void;
 }
 
 const TelemetryMarkers: React.FC<TelemetryMarkersProps & { mapTheme: 'dark' | 'light' }> = ({
@@ -25,6 +27,8 @@ const TelemetryMarkers: React.FC<TelemetryMarkersProps & { mapTheme: 'dark' | 'l
     mapTheme,
     hourFormat = '24',
     canViewSupportAddresses = false,
+    isAdmin = false,
+    onMapPinDeleted,
 }) => {
     const size = getMarkerSize(zoom);
 
@@ -46,6 +50,8 @@ const TelemetryMarkers: React.FC<TelemetryMarkersProps & { mapTheme: 'dark' | 'l
                         mapTheme={mapTheme}
                         hourFormat={hourFormat}
                         canViewSupportAddresses={canViewSupportAddresses}
+                        isAdmin={isAdmin}
+                        onMapPinDeleted={onMapPinDeleted}
                     />
                 ) : null
             )}

--- a/Web/web.client/src/views/RailMap.tsx
+++ b/Web/web.client/src/views/RailMap.tsx
@@ -107,7 +107,7 @@ const RailMap: React.FC = () => {
 
     // Auth for admin button
     const { session, logout } = useAuth();
-    const { canViewSupportAddresses } = parseSessionRoles(session?.roles);
+    const { canViewSupportAddresses, isAdmin } = parseSessionRoles(session?.roles);
 
     // Use custom hooks for data
     const { trackData, trackDataLoading } = useRailways();
@@ -945,6 +945,10 @@ const RailMap: React.FC = () => {
                     mapTheme={mapTheme as 'dark' | 'light'}
                     hourFormat={hourFormat}
                     canViewSupportAddresses={canViewSupportAddresses}
+                    isAdmin={isAdmin}
+                    onMapPinDeleted={(deletedPinId) => {
+                        setMapPins((prevPins: MapPin[]) => prevPins.filter(p => Number(p.id) !== deletedPinId));
+                    }}
                 />}
 
                 {beaconsLoaded && (


### PR DESCRIPTION
## Summary
Fixes the admin emergency reset flow for stuck map pins with overgrown address lists.

### What changed
- Server reset endpoint now deletes the full map pin record (not just addresses) to avoid orphan/duplicate behavior.
- Repository delete flow explicitly removes child addresses before removing the parent map pin.
- Client reset action now removes the deleted pin from local map state immediately so it disappears without page refresh.
- Kept Admin-only enforcement for the reset action.

### Why
Previously, clearing only addresses could leave a pin shell that caused duplicate pin creation on subsequent telemetry merges. The UI also required a manual refresh to reflect the reset.

### Validation
- `dotnet build Web/Web.Server/Web.Server.csproj` succeeded.
- `npm run build` in `Web/web.client` succeeded.

Closes #43.