### PR TITLE
Fix Reset Addresses click no-op in telemetry popup

### DIFF
--- a/Web/web.client/src/components/TelemetryMarker.tsx
+++ b/Web/web.client/src/components/TelemetryMarker.tsx
@@ -422,6 +422,11 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
         marker.on('popupopen', onPopupOpen);
         marker.on('popupclose', onPopupClose);
 
+        // If dependencies changed while the popup stayed open, rebind handlers immediately.
+        if (marker.isPopupOpen()) {
+            onPopupOpen();
+        }
+
         // Reopen popup after tracking state changes to show updated content
         if (shouldReopenPopupRef.current) {
             shouldReopenPopupRef.current = false;

--- a/Web/web.client/src/views/RailMap.tsx
+++ b/Web/web.client/src/views/RailMap.tsx
@@ -1,4 +1,4 @@
-﻿import React, { useEffect, useState, useRef, useMemo } from 'react';
+﻿import React, { useEffect, useState, useRef, useMemo, useCallback } from 'react';
 import HamburgerMenu from '../components/HamburgerMenu';
 import {
     MapContainer,
@@ -556,6 +556,10 @@ const RailMap: React.FC = () => {
         telemetryPins[pin.id] = pin;
     });
 
+    const handleMapPinDeleted = useCallback((deletedPinId: number) => {
+        setMapPins((prevPins: MapPin[]) => prevPins.filter(p => Number(p.id) !== deletedPinId));
+    }, [setMapPins]);
+
     // Use ref to get the map instance
     const mapRef = useRef<LeafletMap | null>(null);
     const railLayerRef = useRef<L.GeoJSON | null>(null);
@@ -946,9 +950,7 @@ const RailMap: React.FC = () => {
                     hourFormat={hourFormat}
                     canViewSupportAddresses={canViewSupportAddresses}
                     isAdmin={isAdmin}
-                    onMapPinDeleted={(deletedPinId) => {
-                        setMapPins((prevPins: MapPin[]) => prevPins.filter(p => Number(p.id) !== deletedPinId));
-                    }}
+                    onMapPinDeleted={handleMapPinDeleted}
                 />}
 
                 {beaconsLoaded && (


### PR DESCRIPTION
## Summary
Fixes a production/local issue where clicking **Reset Addresses** in an open map pin popup could do nothing.

## Root Cause
`TelemetryMarker` rebinds popup handlers in an effect. During normal app re-renders, the effect could run while a popup remained open, detaching handlers and not reattaching them until a future popup reopen. That left the Reset action inert in the currently-open popup.

## Changes
- Stabilized the pin-deletion callback in `RailMap` using `useCallback` to reduce unnecessary effect churn.
- In `TelemetryMarker`, after registering popup events, immediately re-attach handlers when the popup is already open.

## Validation
- `npm run build` in `Web/web.client` succeeded.

## Notes
This is a frontend-only hotfix and does not change server behavior.
