### PR TITLE
docs: add repo-wide consistency guidelines

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,6 +15,16 @@
 - Trace end-to-end impact instead of reasoning from one layer in isolation: API/controller, service/rule engine, repository/data model, SignalR or background services, frontend services/hooks/components, and tests.
 - If you forget about `/plan-feature`, type `/` in chat and it will appear in the prompt list, or consult this section of the project guidelines.
 
+## Consistency Standards
+- Use GitFlow-style branch prefixes so intent is obvious: `feat/`, `fix/`, `docs/`, `refactor/`, `test/`, or `chore/`.
+- Include the issue number in the branch name when one exists, and keep names lowercase with hyphenated slugs.
+- Match pull request tags to the originating issue type when possible, such as `bug`, `enhancement`, `documentation`, or `refactor`.
+- Link the issue number in the PR body and keep the PR scope narrow enough to review in one pass.
+- Requirements should state the user problem, in-scope work, out-of-scope work, expected behavior, acceptance criteria, and test plan.
+- Before coding, identify the affected layers: API, service or rule logic, repository or persistence, frontend, SignalR or background work, and tests.
+- Use the domain vocabulary already defined for beacons, map pins, tracked pins, subdivisions, railroads, and telemetry packets.
+- If a requirement cannot be tested or verified, refine it before implementation starts.
+
 ## Project Conventions
 - Keep controllers thin. Put business rules in services or rule-engine classes, not in controllers.
 - Keep EF Core access in repositories and persistence models in `Web/Web.Server/Entities`.

--- a/.github/instructions/services.instructions.md
+++ b/.github/instructions/services.instructions.md
@@ -1,7 +1,7 @@
 ---
 description: "Use when planning or changing the shared Services library, telemetry deserializers, throttling, subscriber integrations, configuration helpers, resilience policies, or ConsoleApp interactions. Covers files under Services and ConsoleApp."
 name: "Shared Services Instructions"
-applyTo: ["Services/**", "ConsoleApp/**"]
+applyTo: "Services/**,ConsoleApp/**"
 ---
 # Shared Services Instructions
 

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,7 +1,7 @@
 ---
 description: "Use when adding, updating, or reviewing tests, or when planning a feature and you need the best executable description of current behavior. Covers server unit tests, integration tests, and shared services tests."
 name: "Testing Instructions"
-applyTo: ["Web/Web.ServerTests/**", "Web/Web.Server.IntegrationTests/**", "Services.UnitTests/**"]
+applyTo: "Web/Web.ServerTests/**, Web/Web.Server.IntegrationTests/**, Services.UnitTests/**"
 ---
 # Testing Instructions
 


### PR DESCRIPTION
## Summary
Moves the branch naming, PR labeling, and requirement consistency rules into the repo-wide Copilot instructions so they apply to work across the codebase.

## Changes
- Added consistency standards to `.github/copilot-instructions.md`
- Kept the supporting docs aligned with the system overview

## Validation
- `Set-Location docs; npm run build`
