### PR TITLE
Fix map pin address loss by using explicit map-pin removal events

### DIFF
--- a/Web/Web.Server/Hubs/NotificationMethods.cs
+++ b/Web/Web.Server/Hubs/NotificationMethods.cs
@@ -4,6 +4,7 @@
     {
         public const string BeaconUpdate = "BeaconUpdate";
         public const string MapPinUpdate = "MapPinUpdate";
+        public const string MapPinRemoved = "MapPinRemoved";
         public const string TrackedPinRemoved = "TrackedPinRemoved";
         public const string PassengerPinUpdate = "PassengerPinUpdate";
         public const string PassengerPinRemoved = "PassengerPinRemoved";

--- a/Web/Web.Server/Services/MapPinService.cs
+++ b/Web/Web.Server/Services/MapPinService.cs
@@ -374,20 +374,26 @@ namespace Web.Server.Services
                 // Migrate all tracked records from the duplicate to the final merged pin.
                 await _userTrackedPinRepository.UpdateMapPinIdAsync(duplicate.ID, upsertedMapPin.ID);
 
-                await _mapPinRepository.DeleteAsync(duplicate.ID);
-
-                // Notify clients to remove the deleted map pin from live state.
-                var allMapPinClients = _hubContext.Clients?.All;
-                if (allMapPinClients != null)
+                var wasDeleted = await _mapPinRepository.DeleteAsync(duplicate.ID);
+                if (wasDeleted)
                 {
-                    await allMapPinClients.SendCoreAsync(NotificationMethods.MapPinRemoved, [duplicate.ID], default);
+                    // Notify clients to remove the deleted map pin from live state.
+                    var allMapPinClients = _hubContext.Clients?.All;
+                    if (allMapPinClients != null)
+                    {
+                        await allMapPinClients.SendCoreAsync(NotificationMethods.MapPinRemoved, [duplicate.ID], default);
+                    }
+
+                    // Notify clients to remove any stale tracking labels for the deleted pin.
+                    var allClients = _hubContext.Clients?.All;
+                    if (allClients != null)
+                    {
+                        await allClients.SendCoreAsync(NotificationMethods.TrackedPinRemoved, [duplicate.ID], default);
+                    }
                 }
-
-                // Notify clients to remove any stale tracking labels for the deleted pin.
-                var allClients = _hubContext.Clients?.All;
-                if (allClients != null)
+                else
                 {
-                    await allClients.SendCoreAsync(NotificationMethods.TrackedPinRemoved, [duplicate.ID], default);
+                    _logger.LogWarning($"Failed to delete duplicate map pin {duplicate.ID}; skipping removal notifications.");
                 }
             }
 

--- a/Web/Web.Server/Services/MapPinService.cs
+++ b/Web/Web.Server/Services/MapPinService.cs
@@ -376,6 +376,13 @@ namespace Web.Server.Services
 
                 await _mapPinRepository.DeleteAsync(duplicate.ID);
 
+                // Notify clients to remove the deleted map pin from live state.
+                var allMapPinClients = _hubContext.Clients?.All;
+                if (allMapPinClients != null)
+                {
+                    await allMapPinClients.SendCoreAsync(NotificationMethods.MapPinRemoved, [duplicate.ID], default);
+                }
+
                 // Notify clients to remove any stale tracking labels for the deleted pin.
                 var allClients = _hubContext.Clients?.All;
                 if (allClients != null)

--- a/Web/Web.ServerTests/Services/MapPinServiceTests.cs
+++ b/Web/Web.ServerTests/Services/MapPinServiceTests.cs
@@ -4072,6 +4072,10 @@ namespace Web.ServerTests.Services
                     mp.Addresses.Any(a => a.AddressID == existingAddressID && a.Source == SourceEnum.HOT) &&
                     mp.Addresses.Any(a => a.AddressID == newAddressID && a.Source == SourceEnum.EOT)),
                 telemetry.LastUpdate), Times.Once);
+            _clientProxyMock.Verify(proxy => proxy.SendCoreAsync(
+                NotificationMethods.MapPinRemoved,
+                It.Is<object[]>(args => args.Length == 1 && Convert.ToInt32(args[0]) == existingPin.ID),
+                default), Times.Once);
         }
 
         /// <summary>

--- a/Web/web.client/src/hooks/useSignalR.ts
+++ b/Web/web.client/src/hooks/useSignalR.ts
@@ -7,6 +7,7 @@ import { getAuthToken } from "../services/auth";
 
 const beaconUpdateMethodName = "BeaconUpdate";
 const mapPinUpdateMethodName = "MapPinUpdate";
+const mapPinRemovedMethodName = "MapPinRemoved";
 const trackedPinAddedMethodName = "TrackedPinAdded";
 const trackedPinUpdatedMethodName = "TrackedPinUpdated";
 const trackedPinRemovedMethodName = "TrackedPinRemoved";
@@ -16,6 +17,7 @@ const passengerPinRemovedMethodName = "PassengerPinRemoved";
 // Accept handlers for multiple events
 export function useSignalR(handlers: {
     MapPinUpdate?: (mapPin: MapPin) => void;
+    MapPinRemoved?: (mapPinId: number) => void;
     BeaconUpdate?: (beacons: Beacon[]) => void;
     TrackedPinAdded?: (payload: any) => void;
     TrackedPinUpdated?: (payload: any) => void;
@@ -60,6 +62,19 @@ export function useSignalR(handlers: {
             if (handlersRef.current.MapPinUpdate) {
                 connection.on(mapPinUpdateMethodName, (mapPin: MapPin) => {
                     handlersRef.current.MapPinUpdate?.(mapPin);
+                });
+            }
+            if (handlersRef.current.MapPinRemoved) {
+                connection.on(mapPinRemovedMethodName, (payload: any) => {
+                    const id = typeof payload === "number"
+                        ? payload
+                        : typeof payload === "string"
+                            ? parseInt(payload, 10)
+                            : (payload?.mapPinId ?? payload?.id);
+
+                    if (Number.isFinite(id)) {
+                        handlersRef.current.MapPinRemoved?.(Number(id));
+                    }
                 });
             }
             if (handlersRef.current.BeaconUpdate) {
@@ -148,6 +163,7 @@ export function useSignalR(handlers: {
             disposed = true;
             if (connection) {
                 connection.off(mapPinUpdateMethodName);
+                connection.off(mapPinRemovedMethodName);
                 connection.off(beaconUpdateMethodName);
                 connection.off(trackedPinAddedMethodName);
                 connection.off(trackedPinUpdatedMethodName);

--- a/Web/web.client/src/hooks/useSignalR.ts
+++ b/Web/web.client/src/hooks/useSignalR.ts
@@ -66,14 +66,16 @@ export function useSignalR(handlers: {
             }
             if (handlersRef.current.MapPinRemoved) {
                 connection.on(mapPinRemovedMethodName, (payload: any) => {
-                    const id = typeof payload === "number"
+                    const rawId = typeof payload === "number"
                         ? payload
                         : typeof payload === "string"
-                            ? parseInt(payload, 10)
+                            ? payload
                             : (payload?.mapPinId ?? payload?.id);
 
+                    const id = typeof rawId === "number" ? rawId : Number.parseInt(String(rawId), 10);
+
                     if (Number.isFinite(id)) {
-                        handlersRef.current.MapPinRemoved?.(Number(id));
+                        handlersRef.current.MapPinRemoved?.(id);
                     }
                 });
             }

--- a/Web/web.client/src/utils/updateHelpers.test.ts
+++ b/Web/web.client/src/utils/updateHelpers.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import type { MapPin } from '../types/MapPin';
+import { removeMapPin, updateMapPins } from './updateHelpers';
+
+function createMapPin(overrides: Partial<MapPin> = {}): MapPin {
+    return {
+        id: '101',
+        shareCode: 'ABC123',
+        beaconID: '1',
+        beaconName: 'Rugby Jct',
+        latitude: 43,
+        longitude: -88,
+        milepost: 117.2,
+        direction: 'Northbound',
+        moving: true,
+        isLocal: false,
+        railroad: 'CN',
+        subdivision: 'Waukesha Sub',
+        subdivisionID: '10',
+        lastUpdate: '2026-07-11T08:43:00Z',
+        addresses: [
+            { addressID: 12345, source: 'HOT', isActive: true },
+        ],
+        addressSourceTypes: ['HOT'],
+        hasDpu: false,
+        ...overrides,
+    };
+}
+
+describe('updateMapPins', () => {
+    it('replaces an existing pin only when IDs match', () => {
+        const existingPin = createMapPin({ id: '101', addresses: [{ addressID: 11111, source: 'HOT', isActive: true }] });
+        const unchangedPin = createMapPin({ id: '202', beaconID: '2', shareCode: 'ZZZ999' });
+        const incomingPin = createMapPin({ id: '101', addresses: [{ addressID: 22222, source: 'EOT', isActive: true }] });
+
+        const updated = updateMapPins([existingPin, unchangedPin], incomingPin);
+
+        expect(updated).toHaveLength(2);
+        expect(updated.find(p => p.id === '101')?.addresses).toEqual(incomingPin.addresses);
+        expect(updated.find(p => p.id === '202')).toEqual(unchangedPin);
+    });
+
+    it('appends a new pin when ID does not exist', () => {
+        const existingPin = createMapPin({ id: '101' });
+        const incomingPin = createMapPin({ id: '303', shareCode: 'NEW303' });
+
+        const updated = updateMapPins([existingPin], incomingPin);
+
+        expect(updated).toHaveLength(2);
+        expect(updated.find(p => p.id === '303')).toEqual(incomingPin);
+    });
+});
+
+describe('removeMapPin', () => {
+    it('removes only the targeted map pin ID', () => {
+        const firstPin = createMapPin({ id: '101' });
+        const secondPin = createMapPin({ id: '202' });
+
+        const updated = removeMapPin([firstPin, secondPin], 101);
+
+        expect(updated).toHaveLength(1);
+        expect(updated[0].id).toBe('202');
+    });
+});

--- a/Web/web.client/src/utils/updateHelpers.ts
+++ b/Web/web.client/src/utils/updateHelpers.ts
@@ -2,39 +2,12 @@ import { Beacon } from "../types/Beacon";
 import { MapPin } from "../types/MapPin";
 
 export function updateMapPins(pins: MapPin[], newPin: MapPin): MapPin[] {
-    const newAddresses = Array.isArray(newPin.addresses) ? newPin.addresses : [];
+    const remaining = pins.filter(mapPin => String(mapPin.id) !== String(newPin.id));
+    return [...remaining, newPin];
+}
 
-    const sharesIdentity = (mapPin: MapPin): boolean =>
-        !!mapPin.shareCode && !!newPin.shareCode && mapPin.shareCode === newPin.shareCode;
-
-    const sharesAddress = (mapPin: MapPin): boolean =>
-        Array.isArray(mapPin.addresses) &&
-        newAddresses.length > 0 &&
-        mapPin.addresses.some(addr1 =>
-            newAddresses.some(addr2 =>
-                addr1.addressID === addr2.addressID && addr1.source === addr2.source
-            )
-        );
-
-    const merged = pins.filter(mapPin => {
-        // Primary identity: map pin ID from server.
-        if (String(mapPin.id) === String(newPin.id)) {
-            return false;
-        }
-
-        if (sharesIdentity(mapPin)) {
-            return false;
-        }
-
-        // Secondary identity: overlapping address/source tuple.
-        if (sharesAddress(mapPin)) {
-            return false;
-        }
-
-        return true;
-    });
-
-    return [...merged, newPin];
+export function removeMapPin(pins: MapPin[], mapPinId: string | number): MapPin[] {
+    return pins.filter(mapPin => String(mapPin.id) !== String(mapPinId));
 }
 
 export function updateBeacon(beacons: Beacon[], updatedBeacon: Beacon): Beacon[] {

--- a/Web/web.client/src/views/MapPinsLog.tsx
+++ b/Web/web.client/src/views/MapPinsLog.tsx
@@ -6,7 +6,7 @@ import { MapPin } from '../types/MapPin';
 import { format, parseISO } from "date-fns";
 import { getTrackedMapPins, TrackedPin, updateTrackedPinSymbol, refreshTrackedPinsFromApi, applyTrackedPinAddedOrUpdatedFromServer, applyTrackedPinRemovedFromServer } from '../services/trackedPins';
 import { useSignalR } from '../hooks/useSignalR';
-import { updateMapPins } from '../utils/updateHelpers';
+import { removeMapPin, updateMapPins } from '../utils/updateHelpers';
 
 function MapPinsLog() {
     const [mapPins, setMapPins] = useState<MapPin[]>([]);
@@ -39,6 +39,9 @@ function MapPinsLog() {
     useSignalR({
         MapPinUpdate: (mapPin: MapPin) => {
             setMapPins((prevPins: MapPin[]) => updateMapPins(prevPins, mapPin));
+        },
+        MapPinRemoved: (mapPinId: number) => {
+            setMapPins((prevPins: MapPin[]) => removeMapPin(prevPins, mapPinId));
         },
         TrackedPinAdded: (payload: any) => {
             const updated = applyTrackedPinAddedOrUpdatedFromServer(payload);

--- a/Web/web.client/src/views/RailMap.tsx
+++ b/Web/web.client/src/views/RailMap.tsx
@@ -22,7 +22,7 @@ import FindMeControl from '../components/FindMeControl';
 import { BeaconHistoryModal } from '../components/BeaconHistoryModal';
 import { getTrackedMapPins, updateTrackedPinLocation, refreshTrackedPinsFromApi, applyTrackedPinAddedOrUpdatedFromServer, applyTrackedPinRemovedFromServer, addTrackedMapPinByShareCode } from '../services/trackedPins';
 import { metersToLongitudeDegrees, pixelsToMeters } from '../utils/geo';
-import { updateMapPins, updateBeacon } from '../utils/updateHelpers';
+import { updateMapPins, updateBeacon, removeMapPin } from '../utils/updateHelpers';
 import { useRailways } from '../hooks/useRailways';
 import { useBeacons } from '../hooks/useBeacons';
 import { useMileposts } from '../hooks/useMileposts';
@@ -264,6 +264,9 @@ const RailMap: React.FC = () => {
                     return prev;
                 });
             }
+        },
+        MapPinRemoved: (mapPinId: number) => {
+            setMapPins((prevPins: MapPin[]) => removeMapPin(prevPins, mapPinId));
         },
         BeaconUpdate: (beaconBatch: any[]) => {
             setBeacons((prevBeacons: Beacon[]) => {


### PR DESCRIPTION
## Summary
This replaces the reverted PR #64 approach with a deterministic real-time update model:
- server emits explicit `MapPinRemoved` when single-track duplicate merge deletes a pin
- client updates map pins by exact `id` only and removes pins only on explicit remove event

This avoids heuristic merging by share code/address overlap, which could over-merge and regress support address visibility.

## Related issue
Fixes #63

## What changed
- Added `NotificationMethods.MapPinRemoved`
- Emitted `MapPinRemoved` in `MapPinService.MergeSingleTrackDuplicatesAsync` when deleting duplicate pins
- Added server test coverage asserting `MapPinRemoved` emission for duplicate merge path
- Simplified `updateMapPins` to strict ID replacement and added `removeMapPin`
- Added frontend tests for update/remove helper behavior
- Wired `MapPinRemoved` handling into `useSignalR`, `RailMap`, and `MapPinsLog`

## Validation
- `dotnet test Web/Web.ServerTests/Web.Server.Tests.csproj`
- `npm --prefix Web/web.client run test`
- `npm --prefix Web/web.client run build`
