### PR TITLE
Beacon Stale Data Offline Indicator

### DIFF
--- a/Web/Web.Server/Controllers/v1/BeaconRailroadsController.cs
+++ b/Web/Web.Server/Controllers/v1/BeaconRailroadsController.cs
@@ -70,6 +70,12 @@ namespace Web.Server.Controllers.v1
             var response = new MessageEnvelope<BeaconRailroadDTO>(null, []);
             try
             {
+                if (dto.TelemetryStaleHoursOverride.HasValue && dto.TelemetryStaleHoursOverride.Value <= 0)
+                {
+                    response.Errors.Add("TelemetryStaleHoursOverride must be a whole integer greater than zero when provided.");
+                    return BadRequest(response);
+                }
+
                 var beaconRailroad = _mapper.Map<Entities.BeaconRailroad>(dto);
 
                 var created = await _service.AddAsync(beaconRailroad);
@@ -99,6 +105,12 @@ namespace Web.Server.Controllers.v1
                 if (beaconId != dto.BeaconID || subdivisionId != dto.SubdivisionID)
                 {
                     response.Errors.Add("BeaconID and SubdivisionID in the URL must match the DTO.");
+                    return BadRequest(response);
+                }
+
+                if (dto.TelemetryStaleHoursOverride.HasValue && dto.TelemetryStaleHoursOverride.Value <= 0)
+                {
+                    response.Errors.Add("TelemetryStaleHoursOverride must be a whole integer greater than zero when provided.");
                     return BadRequest(response);
                 }
 

--- a/Web/Web.Server/DTOs/BeaconRailroadDTO.cs
+++ b/Web/Web.Server/DTOs/BeaconRailroadDTO.cs
@@ -67,6 +67,20 @@ namespace Web.Server.DTOs
         public bool Online { get; set; }
 
         /// <summary>
+        /// Reports whether telemetry is stale for this beacon railroad.
+        /// True when the health endpoint is pinging but no telemetry has been received
+        /// within the effective telemetry-stale threshold.
+        /// </summary>
+        public bool TelemetryStale { get; set; }
+
+        /// <summary>
+        /// Optional per-record override for the number of hours before telemetry is considered stale.
+        /// When null, the application-level default (TelemetryStaleHoursDefault) is used.
+        /// Must be a whole integer greater than zero when provided.
+        /// </summary>
+        public int? TelemetryStaleHoursOverride { get; set; }
+
+        /// <summary>
         /// The direction in which telemetry data is moving.
         /// </summary>
         /// <example>NorthSouth</example>
@@ -97,6 +111,8 @@ namespace Web.Server.DTOs
                    Longitude == other.Longitude &&
                    Milepost == other.Milepost &&
                    Online == other.Online &&
+                   TelemetryStale == other.TelemetryStale &&
+                   TelemetryStaleHoursOverride == other.TelemetryStaleHoursOverride &&
                    Direction == other.Direction &&
                    CreatedAt == other.CreatedAt &&
                    LastUpdate == other.LastUpdate;
@@ -112,6 +128,8 @@ namespace Web.Server.DTOs
             hash.Add(Longitude);
             hash.Add(Milepost);
             hash.Add(Online);
+            hash.Add(TelemetryStale);
+            hash.Add(TelemetryStaleHoursOverride);
             hash.Add(Direction);
             hash.Add(CreatedAt);
             hash.Add(LastUpdate);

--- a/Web/Web.Server/DTOs/CreateBeaconRailroadDTO.cs
+++ b/Web/Web.Server/DTOs/CreateBeaconRailroadDTO.cs
@@ -52,6 +52,13 @@ namespace Web.Server.DTOs
         /// <example>NorthSouth</example>
         public Direction Direction { get; set; }
 
+        /// <summary>
+        /// Optional per-record override for the number of hours before telemetry is considered stale.
+        /// When null, the application-level default is used.
+        /// Must be a whole integer greater than zero when provided.
+        /// </summary>
+        public int? TelemetryStaleHoursOverride { get; set; }
+
         public override bool Equals(object? obj)
         {
             return Equals(obj as CreateBeaconRailroadDTO);
@@ -67,7 +74,8 @@ namespace Web.Server.DTOs
                    Milepost == other.Milepost &&
                    MultipleTracks == other.MultipleTracks &&
                    Online == other.Online &&
-                   Direction == other.Direction;
+                   Direction == other.Direction &&
+                   TelemetryStaleHoursOverride == other.TelemetryStaleHoursOverride;
         }
 
         public override int GetHashCode()

--- a/Web/Web.Server/Entities/BeaconRailroad.cs
+++ b/Web/Web.Server/Entities/BeaconRailroad.cs
@@ -34,6 +34,13 @@ namespace Web.Server.Entities
         [Required]
         public bool MultipleTracks { get; set; } = false;
 
+        /// <summary>
+        /// Optional per-record override for the number of hours before telemetry is considered stale.
+        /// When null, the application-level default is used.
+        /// Must be a whole integer greater than zero when provided.
+        /// </summary>
+        public int? TelemetryStaleHoursOverride { get; set; }
+
         public override bool Equals(object? obj)
         {
             return Equals(obj as BeaconRailroad);
@@ -53,7 +60,8 @@ namespace Web.Server.Entities
                    Longitude == other.Longitude &&
                    EqualityComparer<ICollection<MapPin>>.Default.Equals(MapPins, other.MapPins) &&
                    Milepost == other.Milepost &&
-                   MultipleTracks == other.MultipleTracks;
+                   MultipleTracks == other.MultipleTracks &&
+                   TelemetryStaleHoursOverride == other.TelemetryStaleHoursOverride;
         }
 
         public override int GetHashCode()
@@ -71,6 +79,7 @@ namespace Web.Server.Entities
             hash.Add(MapPins);
             hash.Add(Milepost);
             hash.Add(MultipleTracks);
+            hash.Add(TelemetryStaleHoursOverride);
             return hash.ToHashCode();
         }
 

--- a/Web/Web.Server/Migrations/20260706013024_AddTelemetryStaleHoursOverride.Designer.cs
+++ b/Web/Web.Server/Migrations/20260706013024_AddTelemetryStaleHoursOverride.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Web.Server.Data;
 
@@ -10,9 +11,11 @@ using Web.Server.Data;
 namespace Web.Server.Migrations
 {
     [DbContext(typeof(TelemetryDbContext))]
-    partial class TelemetryDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260706013024_AddTelemetryStaleHoursOverride")]
+    partial class AddTelemetryStaleHoursOverride
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.4");

--- a/Web/Web.Server/Migrations/20260706013024_AddTelemetryStaleHoursOverride.cs
+++ b/Web/Web.Server/Migrations/20260706013024_AddTelemetryStaleHoursOverride.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Web.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTelemetryStaleHoursOverride : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "TelemetryStaleHoursOverride",
+                table: "BeaconRailroads",
+                type: "INTEGER",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TelemetryStaleHoursOverride",
+                table: "BeaconRailroads");
+        }
+    }
+}

--- a/Web/Web.Server/Repositories/BeaconRailroadRepository.cs
+++ b/Web/Web.Server/Repositories/BeaconRailroadRepository.cs
@@ -59,6 +59,7 @@ namespace Web.Server.Repositories
             existing.Longitude = beaconRailroad.Longitude;
             existing.Milepost = beaconRailroad.Milepost;
             existing.MultipleTracks = beaconRailroad.MultipleTracks;
+            existing.TelemetryStaleHoursOverride = beaconRailroad.TelemetryStaleHoursOverride;
             existing.LastUpdate = _timeProvider.UtcNow;
 
             await _context.SaveChangesAsync();

--- a/Web/Web.Server/Services/BeaconRailroadHealthService.cs
+++ b/Web/Web.Server/Services/BeaconRailroadHealthService.cs
@@ -58,12 +58,18 @@ namespace Web.Server.Services
                     .ThenInclude(s => s.Railroad)
                 .ToList();
 
-            // Build a map of BeaconID -> most recent non-discarded telemetry timestamp
-            var latestTelemetryByBeacon = dbContext.Telemetries
-                .Where(t => !t.Discarded)
-                .GroupBy(t => t.BeaconID)
-                .Select(g => new { BeaconID = g.Key, LastUpdate = g.Max(t => t.LastUpdate) })
-                .ToDictionary(x => x.BeaconID, x => x.LastUpdate);
+            // Build a map of (BeaconID, SubdivisionID) -> most recent train-passage timestamp.
+            // Sourced from MapPinHistories rather than Telemetries: raw Telemetries rows are
+            // purged after 12 hours by RecordCleanupService, which would make any beacon whose
+            // last real train exceeded that window fall into "no telemetry ever received" and
+            // incorrectly report TelemetryStale = false forever, regardless of the configured
+            // override. MapPinHistories is retained for 48 hours and already carries a
+            // per-subdivision SubdivisionId, so this also correctly scopes freshness per
+            // railroad for beacons that serve more than one (e.g. junction beacons).
+            var latestTelemetryByBeaconSubdivision = dbContext.MapPinHistories
+                .GroupBy(mph => new { mph.BeaconID, mph.SubdivisionId })
+                .Select(g => new { g.Key.BeaconID, g.Key.SubdivisionId, LastUpdate = g.Max(mph => mph.LastUpdate) })
+                .ToDictionary(x => (x.BeaconID, x.SubdivisionId), x => x.LastUpdate);
 
             var beaconRailroadDTOs = _mapper.Map<IEnumerable<BeaconRailroadDTO>>(beaconRailroads);
 
@@ -80,13 +86,14 @@ namespace Web.Server.Services
                     var effectiveThresholdHours = beaconRailroadDTO.TelemetryStaleHoursOverride ?? _telemetryStaleHoursDefault;
                     var telemetryCutoff = DateTime.UtcNow.AddHours(-effectiveThresholdHours);
 
-                    if (latestTelemetryByBeacon.TryGetValue(beaconRailroadDTO.BeaconID, out var lastTelemetryTime))
+                    if (latestTelemetryByBeaconSubdivision.TryGetValue((beaconRailroadDTO.BeaconID, beaconRailroadDTO.SubdivisionID), out var lastTelemetryTime))
                     {
                         beaconRailroadDTO.TelemetryStale = lastTelemetryTime <= telemetryCutoff;
                     }
                     else
                     {
-                        // No telemetry ever received — not considered stale
+                        // No train passage recorded for this beacon/subdivision within the
+                        // MapPinHistories retention window — not considered stale
                         beaconRailroadDTO.TelemetryStale = false;
                     }
                 }

--- a/Web/Web.Server/Services/BeaconRailroadHealthService.cs
+++ b/Web/Web.Server/Services/BeaconRailroadHealthService.cs
@@ -14,56 +14,94 @@ namespace Web.Server.Services
         private readonly IHubContext<NotificationHub> _hubContext;
         private readonly IMapper _mapper;
         private readonly IServiceScopeFactory _scopeFactory;
+        private readonly int _telemetryStaleHoursDefault;
 
         public BeaconRailroadHealthService(
             IHubContext<NotificationHub> hubContext,
             IMapper mapper,
-            IServiceScopeFactory scopeFactory)
+            IServiceScopeFactory scopeFactory,
+            IConfiguration configuration)
         {
             _hubContext = hubContext;
             _mapper = mapper;
             _scopeFactory = scopeFactory;
+            _telemetryStaleHoursDefault = configuration.GetValue<int>("ApplicationSettings:TelemetryStaleHoursDefault", 6);
         }
 
         /// <summary>
-        /// Executes the background service to deliver updated beacon data to the UI every 15 minutes.
+        /// Executes the background service to deliver updated beacon data to the UI every minute.
+        /// Sets Online based on the 15-minute health cutoff and TelemetryStale based on the
+        /// effective telemetry-stale threshold (per-record override or app setting default).
         /// </summary>
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             while (!stoppingToken.IsCancellationRequested)
             {
                 using var scope = _scopeFactory.CreateScope();
-
                 var dbContext = scope.ServiceProvider.GetRequiredService<TelemetryDbContext>();
-
-                var cutoff = DateTime.UtcNow.AddMinutes(-15);
-
-                var beaconRailroads = dbContext.BeaconRailroads
-                    .Include(br => br.Beacon)
-                    .Include(br => br.Subdivision)
-                        .ThenInclude(s => s.Railroad)
-                    .ToList();
-
-                var beaconRailroadDTOs = _mapper.Map<IEnumerable<BeaconRailroadDTO>>(beaconRailroads);
-
-                var updatedBeacons = new List<BeaconRailroadDTO>();
-
-                foreach (var beaconRailroadDTO in beaconRailroadDTOs)
-                {
-                    var isOffline = beaconRailroadDTO.LastUpdate != default && beaconRailroadDTO.LastUpdate <= cutoff;
-
-                    beaconRailroadDTO.Online = !isOffline;
-
-                    updatedBeacons.Add(beaconRailroadDTO);
-                }
-
-                // Send all beacons as a single batch to match frontend expectation of Beacon[]
-                if (updatedBeacons.Any())
-                {
-                    await _hubContext.Clients.All.SendAsync(NotificationMethods.BeaconUpdate, updatedBeacons, cancellationToken: stoppingToken);
-                }
-
+                await ComputeAndSendBeaconStatusAsync(dbContext, stoppingToken);
                 await Task.Delay(_cleanupInterval, stoppingToken);
+            }
+        }
+
+        /// <summary>
+        /// Core iteration logic: compute Online and TelemetryStale for all beacon railroads
+        /// and broadcast the result via SignalR.
+        /// </summary>
+        protected internal async Task ComputeAndSendBeaconStatusAsync(TelemetryDbContext dbContext, CancellationToken cancellationToken)
+        {
+            var healthCutoff = DateTime.UtcNow.AddMinutes(-15);
+
+            var beaconRailroads = dbContext.BeaconRailroads
+                .Include(br => br.Beacon)
+                .Include(br => br.Subdivision)
+                    .ThenInclude(s => s.Railroad)
+                .ToList();
+
+            // Build a map of BeaconID -> most recent non-discarded telemetry timestamp
+            var latestTelemetryByBeacon = dbContext.Telemetries
+                .Where(t => !t.Discarded)
+                .GroupBy(t => t.BeaconID)
+                .Select(g => new { BeaconID = g.Key, LastUpdate = g.Max(t => t.LastUpdate) })
+                .ToDictionary(x => x.BeaconID, x => x.LastUpdate);
+
+            var beaconRailroadDTOs = _mapper.Map<IEnumerable<BeaconRailroadDTO>>(beaconRailroads);
+
+            var updatedBeacons = new List<BeaconRailroadDTO>();
+
+            foreach (var beaconRailroadDTO in beaconRailroadDTOs)
+            {
+                var isOffline = beaconRailroadDTO.LastUpdate != default && beaconRailroadDTO.LastUpdate <= healthCutoff;
+
+                beaconRailroadDTO.Online = !isOffline;
+
+                if (beaconRailroadDTO.Online)
+                {
+                    var effectiveThresholdHours = beaconRailroadDTO.TelemetryStaleHoursOverride ?? _telemetryStaleHoursDefault;
+                    var telemetryCutoff = DateTime.UtcNow.AddHours(-effectiveThresholdHours);
+
+                    if (latestTelemetryByBeacon.TryGetValue(beaconRailroadDTO.BeaconID, out var lastTelemetryTime))
+                    {
+                        beaconRailroadDTO.TelemetryStale = lastTelemetryTime <= telemetryCutoff;
+                    }
+                    else
+                    {
+                        // No telemetry ever received — not considered stale
+                        beaconRailroadDTO.TelemetryStale = false;
+                    }
+                }
+                else
+                {
+                    beaconRailroadDTO.TelemetryStale = false;
+                }
+
+                updatedBeacons.Add(beaconRailroadDTO);
+            }
+
+            // Send all beacons as a single batch to match frontend expectation of Beacon[]
+            if (updatedBeacons.Any())
+            {
+                await _hubContext.Clients.All.SendAsync(NotificationMethods.BeaconUpdate, updatedBeacons, cancellationToken: cancellationToken);
             }
         }
     }

--- a/Web/Web.Server/appsettings.json
+++ b/Web/Web.Server/appsettings.json
@@ -2,7 +2,8 @@
   "ApplicationSettings": {
     "ApiKey": "8718271d-b8da-43ff-a252-5623dde3d8d5",
     "HistoryTimeThresholdMinutes": 360,
-    "StationaryDirectionNullThresholdHours": 6
+    "StationaryDirectionNullThresholdHours": 6,
+    "TelemetryStaleHoursDefault": 6
   },
   "ConnectionStrings": {
     "TelemetryDatabase": "Data Source=telemetry.db"

--- a/Web/Web.ServerTests/Repositories/BeaconRailroadRepositoryTests.cs
+++ b/Web/Web.ServerTests/Repositories/BeaconRailroadRepositoryTests.cs
@@ -1,0 +1,149 @@
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Web.Server.Data;
+using Web.Server.Entities;
+using Web.Server.Enums;
+using Web.Server.Providers;
+using Web.Server.Repositories;
+
+namespace Web.ServerTests.Repositories
+{
+    [TestClass]
+    public class BeaconRailroadRepositoryTests
+    {
+        [TestMethod]
+        public async Task UpdateAsync_PersistsTelemetryStaleHoursOverride_WhenSet()
+        {
+            var now = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc);
+            var (context, timeProviderMock) = BuildContext(now);
+
+            await SeedBeaconRailroadAsync(context, now, telemetryStaleHoursOverride: null);
+
+            var repository = new BeaconRailroadRepository(context, timeProviderMock.Object);
+            var update = new BeaconRailroad
+            {
+                BeaconID = 1,
+                SubdivisionID = 1,
+                Direction = Direction.NorthSouth,
+                Latitude = 43.3,
+                Longitude = -88.2,
+                Milepost = 101.5,
+                MultipleTracks = true,
+                TelemetryStaleHoursOverride = 1
+            };
+
+            await repository.UpdateAsync(update);
+
+            var persisted = await context.BeaconRailroads.FirstAsync(br => br.BeaconID == 1 && br.SubdivisionID == 1);
+            Assert.AreEqual(1, persisted.TelemetryStaleHoursOverride);
+        }
+
+        [TestMethod]
+        public async Task UpdateAsync_ClearsTelemetryStaleHoursOverride_WhenNull()
+        {
+            var now = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc);
+            var (context, timeProviderMock) = BuildContext(now);
+
+            await SeedBeaconRailroadAsync(context, now, telemetryStaleHoursOverride: 6);
+
+            var repository = new BeaconRailroadRepository(context, timeProviderMock.Object);
+            var update = new BeaconRailroad
+            {
+                BeaconID = 1,
+                SubdivisionID = 1,
+                Direction = Direction.NorthSouth,
+                Latitude = 43.3,
+                Longitude = -88.2,
+                Milepost = 101.5,
+                MultipleTracks = true,
+                TelemetryStaleHoursOverride = null
+            };
+
+            await repository.UpdateAsync(update);
+
+            var persisted = await context.BeaconRailroads.FirstAsync(br => br.BeaconID == 1 && br.SubdivisionID == 1);
+            Assert.IsNull(persisted.TelemetryStaleHoursOverride);
+        }
+
+        private static (TelemetryDbContext Context, Mock<ITimeProvider> TimeProviderMock) BuildContext(DateTime now)
+        {
+            var options = new DbContextOptionsBuilder<TelemetryDbContext>()
+                .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+                .Options;
+
+            var timeProviderMock = new Mock<ITimeProvider>();
+            timeProviderMock.Setup(tp => tp.UtcNow).Returns(now);
+
+            var context = new TelemetryDbContext(options);
+            return (context, timeProviderMock);
+        }
+
+        private static async Task SeedBeaconRailroadAsync(TelemetryDbContext context, DateTime now, int? telemetryStaleHoursOverride)
+        {
+            var owner = new User
+            {
+                ID = 1,
+                FirstName = "Test",
+                LastName = "Owner",
+                Email = "owner@example.com",
+                IsActive = true,
+                CreatedAt = now,
+                LastUpdate = now
+            };
+
+            var railroad = new Railroad
+            {
+                ID = 1,
+                Name = "CN",
+                Subdivisions = [],
+                CreatedAt = now,
+                LastUpdate = now
+            };
+
+            var subdivision = new Subdivision
+            {
+                ID = 1,
+                RailroadID = 1,
+                Railroad = railroad,
+                Name = "Neenah",
+                DpuCapable = true,
+                CreatedAt = now,
+                LastUpdate = now
+            };
+
+            var beacon = new Beacon
+            {
+                ID = 1,
+                OwnerID = 1,
+                Owner = owner,
+                Name = "Beacon A",
+                CreatedAt = now,
+                LastUpdate = now
+            };
+
+            var beaconRailroad = new BeaconRailroad
+            {
+                BeaconID = 1,
+                SubdivisionID = 1,
+                Beacon = beacon,
+                Subdivision = subdivision,
+                Direction = Direction.All,
+                Latitude = 43.1,
+                Longitude = -88.1,
+                Milepost = 100.0,
+                MultipleTracks = false,
+                TelemetryStaleHoursOverride = telemetryStaleHoursOverride,
+                CreatedAt = now,
+                LastUpdate = now
+            };
+
+            context.Users.Add(owner);
+            context.Railroads.Add(railroad);
+            context.Subdivisions.Add(subdivision);
+            context.Beacons.Add(beacon);
+            context.BeaconRailroads.Add(beaconRailroad);
+
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/Web/Web.ServerTests/Services/BeaconRailroadHealthServiceTests.cs
+++ b/Web/Web.ServerTests/Services/BeaconRailroadHealthServiceTests.cs
@@ -222,6 +222,34 @@ namespace Web.ServerTests.Services
         }
 
         [TestMethod]
+        public void StateClassification_TelemetryOlderThanTelemetriesRetentionWindow_StillReportsStale()
+        {
+            // Reproduces the "Eagle" production bug: RecordCleanupService purges raw Telemetries
+            // rows after 12 hours, but a beacon can easily go 12+ hours without a real train on a
+            // low-traffic subdivision. The last train passage (17h ago, well past that window, and
+            // well past a 1h override) must still be visible via MapPinHistories (48h retention).
+            var dbName = nameof(StateClassification_TelemetryOlderThanTelemetriesRetentionWindow_StillReportsStale);
+            using var dbContext = CreateInMemoryDbContext(dbName);
+
+            SeedHealthyBeacon(dbContext, beaconId: 1, subdivisionId: 1, telemetryStaleHoursOverride: 1,
+                lastHealthUpdate: DateTime.UtcNow, // health-ping still fresh, beacon appears online
+                lastTelemetryUpdate: DateTime.UtcNow.AddHours(-17)); // last real train, well past both the 1h override and the 12h Telemetries retention window
+
+            _serviceProviderMock.Setup(sp => sp.GetService(typeof(TelemetryDbContext))).Returns(dbContext);
+
+            var config = BuildConfig(defaultHours: 6);
+            var sentDTOs = CaptureBeaconUpdate();
+
+            RunOneIteration(config, dbContext);
+
+            var dto = sentDTOs.First(d => d.BeaconID == 1);
+            Assert.IsTrue(dto.Online, "Health-ping is fresh, so beacon should still appear online");
+            Assert.IsTrue(dto.TelemetryStale,
+                "Last train was 17h ago (> 1h override); this must be reported stale even though a " +
+                "Telemetries row that old would already have been purged by RecordCleanupService");
+        }
+
+        [TestMethod]
         public void StateClassification_HealthyBeacon_NoStaleFlags()
         {
             // Beacon: health fresh and telemetry fresh → fully healthy
@@ -393,12 +421,11 @@ namespace Web.ServerTests.Services
                 CreatedAt = lastHealthUpdate,
                 LastUpdate = lastHealthUpdate
             });
-            dbContext.Telemetries.Add(new Telemetry
+            dbContext.MapPinHistories.Add(new MapPinHistory
             {
                 BeaconID = beaconId,
-                AddressID = 1,
-                Source = "HOT",
-                Discarded = false,
+                SubdivisionId = subdivisionId,
+                AddressesJson = "[]",
                 CreatedAt = lastTelemetryUpdate,
                 LastUpdate = lastTelemetryUpdate
             });

--- a/Web/Web.ServerTests/Services/BeaconRailroadHealthServiceTests.cs
+++ b/Web/Web.ServerTests/Services/BeaconRailroadHealthServiceTests.cs
@@ -1,0 +1,433 @@
+using Mapster;
+using MapsterMapper;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Web.Server.Data;
+using Web.Server.DTOs;
+using Web.Server.Entities;
+using Web.Server.Enums;
+using Web.Server.Hubs;
+using Web.Server.Mappers;
+using Web.Server.Services;
+
+namespace Web.ServerTests.Services
+{
+    [TestClass]
+    public class BeaconRailroadHealthServiceTests
+    {
+        private Mock<IHubContext<NotificationHub>> _hubContextMock;
+        private Mock<IServiceScopeFactory> _scopeFactoryMock;
+        private Mock<IServiceScope> _scopeMock;
+        private Mock<IServiceProvider> _serviceProviderMock;
+        private IMapper _mapper;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _hubContextMock = new Mock<IHubContext<NotificationHub>>();
+            _scopeFactoryMock = new Mock<IServiceScopeFactory>();
+            _scopeMock = new Mock<IServiceScope>();
+            _serviceProviderMock = new Mock<IServiceProvider>();
+
+            var clientsMock = new Mock<IHubClients>();
+            var clientProxyMock = new Mock<IClientProxy>();
+            clientsMock.Setup(c => c.All).Returns(clientProxyMock.Object);
+            _hubContextMock.Setup(h => h.Clients).Returns(clientsMock.Object);
+
+            _scopeMock.Setup(s => s.ServiceProvider).Returns(_serviceProviderMock.Object);
+            _scopeFactoryMock.Setup(f => f.CreateScope()).Returns(_scopeMock.Object);
+
+            var config = new TypeAdapterConfig();
+            config.Scan(typeof(MapsterProfile).Assembly);
+            _mapper = new ServiceMapper(new ServiceCollection().BuildServiceProvider(), config);
+        }
+
+        private TelemetryDbContext CreateInMemoryDbContext(string dbName)
+        {
+            var options = new DbContextOptionsBuilder<TelemetryDbContext>()
+                .UseInMemoryDatabase(databaseName: dbName)
+                .Options;
+            return new TelemetryDbContext(options);
+        }
+
+        private IConfiguration BuildConfig(int defaultHours = 6)
+        {
+            var inMemorySettings = new Dictionary<string, string?>
+            {
+                { "ApplicationSettings:TelemetryStaleHoursDefault", defaultHours.ToString() }
+            };
+            return new ConfigurationBuilder()
+                .AddInMemoryCollection(inMemorySettings)
+                .Build();
+        }
+
+        private BeaconRailroadHealthService CreateService(IConfiguration config)
+        {
+            return new BeaconRailroadHealthService(
+                _hubContextMock.Object,
+                _mapper,
+                _scopeFactoryMock.Object,
+                config);
+        }
+
+        // ── Threshold resolution ────────────────────────────────────────────────
+
+        [TestMethod]
+        public void EffectiveThreshold_UsesOverride_WhenOverrideIsSet()
+        {
+            // The BeaconRailroadHealthService reads per-record override first.
+            // We verify this by creating a beacon with an override and checking that
+            // TelemetryStale is computed using the override threshold.
+            var dbName = nameof(EffectiveThreshold_UsesOverride_WhenOverrideIsSet);
+            using var dbContext = CreateInMemoryDbContext(dbName);
+
+            // Beacon with a 2-hour override; telemetry received 3 hours ago → stale
+            SeedHealthyBeacon(dbContext, beaconId: 1, subdivisionId: 1, telemetryStaleHoursOverride: 2,
+                lastHealthUpdate: DateTime.UtcNow,
+                lastTelemetryUpdate: DateTime.UtcNow.AddHours(-3));
+
+            _serviceProviderMock.Setup(sp => sp.GetService(typeof(TelemetryDbContext))).Returns(dbContext);
+
+            var config = BuildConfig(defaultHours: 6);
+            var sentDTOs = CaptureBeaconUpdate();
+
+            // Act: run one iteration
+            RunOneIteration(config, dbContext);
+
+            // Assert: TelemetryStale = true because 3h > 2h override
+            Assert.IsTrue(sentDTOs.Any(), "Should have sent at least one DTO");
+            var dto = sentDTOs.First(d => d.BeaconID == 1);
+            Assert.IsTrue(dto.Online, "Beacon should be online (health is fresh)");
+            Assert.IsTrue(dto.TelemetryStale, "TelemetryStale should be true — 3h > 2h override");
+        }
+
+        [TestMethod]
+        public void EffectiveThreshold_UsesDefault_WhenOverrideIsNull()
+        {
+            // Beacon has no override; telemetry received 7 hours ago with default 6h → stale
+            var dbName = nameof(EffectiveThreshold_UsesDefault_WhenOverrideIsNull);
+            using var dbContext = CreateInMemoryDbContext(dbName);
+
+            SeedHealthyBeacon(dbContext, beaconId: 1, subdivisionId: 1, telemetryStaleHoursOverride: null,
+                lastHealthUpdate: DateTime.UtcNow,
+                lastTelemetryUpdate: DateTime.UtcNow.AddHours(-7));
+
+            _serviceProviderMock.Setup(sp => sp.GetService(typeof(TelemetryDbContext))).Returns(dbContext);
+
+            var config = BuildConfig(defaultHours: 6);
+            var sentDTOs = CaptureBeaconUpdate();
+
+            RunOneIteration(config, dbContext);
+
+            var dto = sentDTOs.First(d => d.BeaconID == 1);
+            Assert.IsTrue(dto.Online);
+            Assert.IsTrue(dto.TelemetryStale, "TelemetryStale should be true — 7h > default 6h");
+        }
+
+        [TestMethod]
+        public void EffectiveThreshold_NotStale_WhenTelemetryWithinDefault()
+        {
+            // Telemetry received 3 hours ago with default 6h → not stale
+            var dbName = nameof(EffectiveThreshold_NotStale_WhenTelemetryWithinDefault);
+            using var dbContext = CreateInMemoryDbContext(dbName);
+
+            SeedHealthyBeacon(dbContext, beaconId: 1, subdivisionId: 1, telemetryStaleHoursOverride: null,
+                lastHealthUpdate: DateTime.UtcNow,
+                lastTelemetryUpdate: DateTime.UtcNow.AddHours(-3));
+
+            _serviceProviderMock.Setup(sp => sp.GetService(typeof(TelemetryDbContext))).Returns(dbContext);
+
+            var config = BuildConfig(defaultHours: 6);
+            var sentDTOs = CaptureBeaconUpdate();
+
+            RunOneIteration(config, dbContext);
+
+            var dto = sentDTOs.First(d => d.BeaconID == 1);
+            Assert.IsTrue(dto.Online);
+            Assert.IsFalse(dto.TelemetryStale, "TelemetryStale should be false — 3h < default 6h");
+        }
+
+        [TestMethod]
+        public void EffectiveThreshold_NotStale_WhenTelemetryWithinOverride()
+        {
+            // Telemetry received 1 hour ago with 2h override → not stale
+            var dbName = nameof(EffectiveThreshold_NotStale_WhenTelemetryWithinOverride);
+            using var dbContext = CreateInMemoryDbContext(dbName);
+
+            SeedHealthyBeacon(dbContext, beaconId: 1, subdivisionId: 1, telemetryStaleHoursOverride: 2,
+                lastHealthUpdate: DateTime.UtcNow,
+                lastTelemetryUpdate: DateTime.UtcNow.AddHours(-1));
+
+            _serviceProviderMock.Setup(sp => sp.GetService(typeof(TelemetryDbContext))).Returns(dbContext);
+
+            var config = BuildConfig(defaultHours: 6);
+            var sentDTOs = CaptureBeaconUpdate();
+
+            RunOneIteration(config, dbContext);
+
+            var dto = sentDTOs.First(d => d.BeaconID == 1);
+            Assert.IsTrue(dto.Online);
+            Assert.IsFalse(dto.TelemetryStale, "TelemetryStale should be false — 1h < 2h override");
+        }
+
+        // ── State classification ────────────────────────────────────────────────
+
+        [TestMethod]
+        public void StateClassification_HealthOffline_IsGrayState()
+        {
+            // Beacon with LastUpdate > 15 min ago → Online = false, TelemetryStale = false
+            var dbName = nameof(StateClassification_HealthOffline_IsGrayState);
+            using var dbContext = CreateInMemoryDbContext(dbName);
+
+            SeedHealthyBeacon(dbContext, beaconId: 1, subdivisionId: 1, telemetryStaleHoursOverride: null,
+                lastHealthUpdate: DateTime.UtcNow.AddMinutes(-20), // offline
+                lastTelemetryUpdate: DateTime.UtcNow.AddHours(-1));
+
+            _serviceProviderMock.Setup(sp => sp.GetService(typeof(TelemetryDbContext))).Returns(dbContext);
+
+            var config = BuildConfig(defaultHours: 6);
+            var sentDTOs = CaptureBeaconUpdate();
+
+            RunOneIteration(config, dbContext);
+
+            var dto = sentDTOs.First(d => d.BeaconID == 1);
+            Assert.IsFalse(dto.Online, "Beacon should be offline (health-offline = gray state)");
+            Assert.IsFalse(dto.TelemetryStale, "TelemetryStale should be false when health-offline");
+        }
+
+        [TestMethod]
+        public void StateClassification_HealthOnline_TelemetryStale_IsBlueRingState()
+        {
+            // Beacon: health is fresh (within 15 min), telemetry is stale (> threshold)
+            var dbName = nameof(StateClassification_HealthOnline_TelemetryStale_IsBlueRingState);
+            using var dbContext = CreateInMemoryDbContext(dbName);
+
+            SeedHealthyBeacon(dbContext, beaconId: 1, subdivisionId: 1, telemetryStaleHoursOverride: null,
+                lastHealthUpdate: DateTime.UtcNow.AddMinutes(-5), // health online
+                lastTelemetryUpdate: DateTime.UtcNow.AddHours(-8)); // telemetry stale (> 6h default)
+
+            _serviceProviderMock.Setup(sp => sp.GetService(typeof(TelemetryDbContext))).Returns(dbContext);
+
+            var config = BuildConfig(defaultHours: 6);
+            var sentDTOs = CaptureBeaconUpdate();
+
+            RunOneIteration(config, dbContext);
+
+            var dto = sentDTOs.First(d => d.BeaconID == 1);
+            Assert.IsTrue(dto.Online, "Beacon should be online (blue-ring state)");
+            Assert.IsTrue(dto.TelemetryStale, "TelemetryStale should be true (blue-ring state)");
+        }
+
+        [TestMethod]
+        public void StateClassification_HealthyBeacon_NoStaleFlags()
+        {
+            // Beacon: health fresh and telemetry fresh → fully healthy
+            var dbName = nameof(StateClassification_HealthyBeacon_NoStaleFlags);
+            using var dbContext = CreateInMemoryDbContext(dbName);
+
+            SeedHealthyBeacon(dbContext, beaconId: 1, subdivisionId: 1, telemetryStaleHoursOverride: null,
+                lastHealthUpdate: DateTime.UtcNow.AddMinutes(-5),
+                lastTelemetryUpdate: DateTime.UtcNow.AddHours(-2)); // within 6h default
+
+            _serviceProviderMock.Setup(sp => sp.GetService(typeof(TelemetryDbContext))).Returns(dbContext);
+
+            var config = BuildConfig(defaultHours: 6);
+            var sentDTOs = CaptureBeaconUpdate();
+
+            RunOneIteration(config, dbContext);
+
+            var dto = sentDTOs.First(d => d.BeaconID == 1);
+            Assert.IsTrue(dto.Online, "Beacon should be online");
+            Assert.IsFalse(dto.TelemetryStale, "TelemetryStale should be false for healthy beacon");
+        }
+
+        [TestMethod]
+        public void StateClassification_NoTelemetryEver_NotConsideredStale()
+        {
+            // Beacon: health fresh, but no telemetry records at all → TelemetryStale = false
+            var dbName = nameof(StateClassification_NoTelemetryEver_NotConsideredStale);
+            using var dbContext = CreateInMemoryDbContext(dbName);
+
+            // Add beacon railroad with no telemetry
+            var beacon = new Beacon
+            {
+                ID = 1,
+                OwnerID = 1,
+                Name = "TestBeacon",
+                CreatedAt = DateTime.UtcNow.AddMinutes(-5),
+                LastUpdate = DateTime.UtcNow.AddMinutes(-5)
+            };
+            var subdivision = new Subdivision { ID = 1, Name = "TestSub", RailroadID = 1, CustodianId = null };
+            var railroad = new Railroad { ID = 1, Name = "TestRR" };
+            subdivision.Railroad = railroad;
+
+            dbContext.Railroads.Add(railroad);
+            dbContext.Subdivisions.Add(subdivision);
+            dbContext.Beacons.Add(beacon);
+            dbContext.BeaconRailroads.Add(new BeaconRailroad
+            {
+                BeaconID = 1,
+                SubdivisionID = 1,
+                Beacon = beacon,
+                Subdivision = subdivision,
+                Direction = Direction.All,
+                Latitude = 0,
+                Longitude = 0,
+                Milepost = 0,
+                MultipleTracks = false,
+                CreatedAt = DateTime.UtcNow.AddMinutes(-5),
+                LastUpdate = DateTime.UtcNow.AddMinutes(-5) // health online
+            });
+            dbContext.SaveChanges();
+
+            _serviceProviderMock.Setup(sp => sp.GetService(typeof(TelemetryDbContext))).Returns(dbContext);
+
+            var config = BuildConfig(defaultHours: 6);
+            var sentDTOs = CaptureBeaconUpdate();
+
+            RunOneIteration(config, dbContext);
+
+            var dto = sentDTOs.First(d => d.BeaconID == 1);
+            Assert.IsTrue(dto.Online, "Beacon should be online");
+            Assert.IsFalse(dto.TelemetryStale, "TelemetryStale should be false when no telemetry ever received");
+        }
+
+        // ── TelemetryStaleHoursOverride passthrough in DTO ────────────────────
+
+        [TestMethod]
+        public void OverrideField_IsIncludedInSentDTO()
+        {
+            var dbName = nameof(OverrideField_IsIncludedInSentDTO);
+            using var dbContext = CreateInMemoryDbContext(dbName);
+
+            SeedHealthyBeacon(dbContext, beaconId: 1, subdivisionId: 1, telemetryStaleHoursOverride: 12,
+                lastHealthUpdate: DateTime.UtcNow,
+                lastTelemetryUpdate: DateTime.UtcNow.AddHours(-1));
+
+            _serviceProviderMock.Setup(sp => sp.GetService(typeof(TelemetryDbContext))).Returns(dbContext);
+
+            var config = BuildConfig(defaultHours: 6);
+            var sentDTOs = CaptureBeaconUpdate();
+
+            RunOneIteration(config, dbContext);
+
+            var dto = sentDTOs.First(d => d.BeaconID == 1);
+            Assert.AreEqual(12, dto.TelemetryStaleHoursOverride, "TelemetryStaleHoursOverride should be 12 as set on the entity");
+        }
+
+        // ── Helpers ────────────────────────────────────────────────────────────
+
+        private List<BeaconRailroadDTO> CaptureBeaconUpdate()
+        {
+            var captured = new List<BeaconRailroadDTO>();
+            var clientsMock = new Mock<IHubClients>();
+            var clientProxyMock = new Mock<IClientProxy>();
+
+            clientProxyMock
+                .Setup(c => c.SendCoreAsync(
+                    NotificationMethods.BeaconUpdate,
+                    It.IsAny<object[]>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<string, object[], CancellationToken>((method, args, ct) =>
+                {
+                    if (args.Length > 0 && args[0] is IEnumerable<BeaconRailroadDTO> dtos)
+                        captured.AddRange(dtos);
+                })
+                .Returns(Task.CompletedTask);
+
+            clientsMock.Setup(c => c.All).Returns(clientProxyMock.Object);
+            _hubContextMock.Setup(h => h.Clients).Returns(clientsMock.Object);
+
+            return captured;
+        }
+
+        private void RunOneIteration(IConfiguration config, TelemetryDbContext dbContext)
+        {
+            // Bypass the background service loop by directly calling the logic
+            // via a test-accessible shim using reflection on a testable subclass.
+            var service = new TestableBeaconRailroadHealthService(
+                _hubContextMock.Object, _mapper, _scopeFactoryMock.Object, config, dbContext);
+
+            service.RunIteration().GetAwaiter().GetResult();
+        }
+
+        private void SeedHealthyBeacon(TelemetryDbContext dbContext, int beaconId, int subdivisionId,
+            int? telemetryStaleHoursOverride, DateTime lastHealthUpdate, DateTime lastTelemetryUpdate)
+        {
+            var beacon = new Beacon
+            {
+                ID = beaconId,
+                OwnerID = 1,
+                Name = $"Beacon{beaconId}",
+                CreatedAt = lastHealthUpdate,
+                LastUpdate = lastHealthUpdate
+            };
+            var railroad = new Railroad { ID = subdivisionId, Name = $"RR{subdivisionId}" };
+            var subdivision = new Subdivision
+            {
+                ID = subdivisionId,
+                Name = $"Sub{subdivisionId}",
+                RailroadID = subdivisionId,
+                Railroad = railroad,
+                CustodianId = null
+            };
+
+            dbContext.Railroads.Add(railroad);
+            dbContext.Subdivisions.Add(subdivision);
+            dbContext.Beacons.Add(beacon);
+            dbContext.BeaconRailroads.Add(new BeaconRailroad
+            {
+                BeaconID = beaconId,
+                SubdivisionID = subdivisionId,
+                Beacon = beacon,
+                Subdivision = subdivision,
+                Direction = Direction.All,
+                Latitude = 0,
+                Longitude = 0,
+                Milepost = 0,
+                MultipleTracks = false,
+                TelemetryStaleHoursOverride = telemetryStaleHoursOverride,
+                CreatedAt = lastHealthUpdate,
+                LastUpdate = lastHealthUpdate
+            });
+            dbContext.Telemetries.Add(new Telemetry
+            {
+                BeaconID = beaconId,
+                AddressID = 1,
+                Source = "HOT",
+                Discarded = false,
+                CreatedAt = lastTelemetryUpdate,
+                LastUpdate = lastTelemetryUpdate
+            });
+            dbContext.SaveChanges();
+        }
+    }
+
+    /// <summary>
+    /// Testable subclass of BeaconRailroadHealthService that exposes the iteration
+    /// logic directly without requiring the background service loop.
+    /// </summary>
+    internal class TestableBeaconRailroadHealthService : BeaconRailroadHealthService
+    {
+        private readonly TelemetryDbContext _testDbContext;
+
+        public TestableBeaconRailroadHealthService(
+            IHubContext<NotificationHub> hubContext,
+            IMapper mapper,
+            IServiceScopeFactory scopeFactory,
+            IConfiguration configuration,
+            TelemetryDbContext testDbContext)
+            : base(hubContext, mapper, scopeFactory, configuration)
+        {
+            _testDbContext = testDbContext;
+        }
+
+        public async Task RunIteration()
+        {
+            await ComputeAndSendBeaconStatusAsync(_testDbContext, CancellationToken.None);
+        }
+    }
+}

--- a/Web/Web.ServerTests/Web.Server.Tests.csproj
+++ b/Web/Web.ServerTests/Web.Server.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Mapster.DependencyInjection" Version="1.0.1" />
     <PackageReference Include="CloneExtensions" Version="1.4.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq.EntityFrameworkCore" Version="9.0.0.5" />
     <PackageReference Include="MSTest" Version="3.8.3" />

--- a/Web/web.client/src/api/beaconsApi.test.ts
+++ b/Web/web.client/src/api/beaconsApi.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchBeacons } from './beaconsApi';
+import { openRailwaysDB } from './db';
+import { fetchWithAuth } from '../utils/fetchWithAuth';
+
+vi.mock('./db', () => ({
+  openRailwaysDB: vi.fn()
+}));
+
+vi.mock('../utils/fetchWithAuth', () => ({
+  fetchWithAuth: vi.fn()
+}));
+
+const mockedOpenRailwaysDB = vi.mocked(openRailwaysDB);
+const mockedFetchWithAuth = vi.mocked(fetchWithAuth);
+
+function makeFakeDb(cached: any) {
+  return {
+    get: vi.fn().mockResolvedValue(cached),
+    put: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined)
+  };
+}
+
+describe('fetchBeacons (soft-refresh / visibility-change path)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockedOpenRailwaysDB.mockReset();
+    mockedFetchWithAuth.mockReset();
+  });
+
+  it('reproduces the bug scenario: preserves a SignalR-confirmed telemetryStale=true instead of reverting it to the cached false', async () => {
+    // Simulates the exact production failure: IndexedDB cache holds a snapshot
+    // from the REST endpoint (which never computes staleness, so telemetryStale
+    // is always false there), while localStorage holds the freshest truth that
+    // SignalR pushed a minute ago (beacon 42 has gone stale).
+    const cachedBeacons = [
+      { beaconID: '42', beaconName: 'Owen', online: true, telemetryStale: false }
+    ];
+    mockedOpenRailwaysDB.mockResolvedValue(makeFakeDb(cachedBeacons) as any);
+    localStorage.setItem('beaconStatusMap', JSON.stringify({ '42': true }));
+    localStorage.setItem('beaconTelemetryStaleMap', JSON.stringify({ '42': true }));
+
+    const setBeacons = vi.fn();
+    const setBeaconsLoaded = vi.fn();
+
+    await fetchBeacons(setBeacons, setBeaconsLoaded);
+
+    expect(setBeacons).toHaveBeenCalledTimes(1);
+    const result = setBeacons.mock.calls[0][0];
+    expect(result).toEqual([
+      { beaconID: '42', beaconName: 'Owen', online: true, telemetryStale: true }
+    ]);
+    expect(setBeaconsLoaded).toHaveBeenCalledWith(true);
+    // The bare REST endpoint should never be hit once a cache entry exists.
+    expect(mockedFetchWithAuth).not.toHaveBeenCalled();
+  });
+
+  it('leaves telemetryStale as-is when nothing has been recorded for that beacon yet', async () => {
+    const cachedBeacons = [
+      { beaconID: '99', beaconName: 'NewBeacon', online: true, telemetryStale: false }
+    ];
+    mockedOpenRailwaysDB.mockResolvedValue(makeFakeDb(cachedBeacons) as any);
+    // No beaconTelemetryStaleMap entry for beacon 99.
+
+    const setBeacons = vi.fn();
+    const setBeaconsLoaded = vi.fn();
+
+    await fetchBeacons(setBeacons, setBeaconsLoaded);
+
+    const result = setBeacons.mock.calls[0][0];
+    expect(result[0].telemetryStale).toBe(false);
+  });
+
+  it('still applies the existing online grace-period overlay alongside the new telemetryStale preservation', async () => {
+    const cachedBeacons = [
+      { beaconID: '7', beaconName: 'Flicker', online: false, telemetryStale: true }
+    ];
+    mockedOpenRailwaysDB.mockResolvedValue(makeFakeDb(cachedBeacons) as any);
+    localStorage.setItem('beaconStatusMap', JSON.stringify({ '7': true }));
+    localStorage.setItem('focusGraceUntil', String(Date.now() + 5000));
+
+    const setBeacons = vi.fn();
+    const setBeaconsLoaded = vi.fn();
+
+    await fetchBeacons(setBeacons, setBeaconsLoaded);
+
+    const result = setBeacons.mock.calls[0][0];
+    expect(result[0].online).toBe(true); // preserved via grace period, unchanged behavior
+    expect(result[0].telemetryStale).toBe(true); // untouched, no stored override present
+  });
+});

--- a/Web/web.client/src/api/beaconsApi.ts
+++ b/Web/web.client/src/api/beaconsApi.ts
@@ -20,16 +20,28 @@ export const fetchBeacons = async (setBeacons: any, setBeaconsLoaded: any) => {
     const raw = localStorage.getItem('beaconStatusMap');
     if (raw) statusMap = JSON.parse(raw);
   } catch { /* ignore */ }
+  let telemetryStaleMap: Record<string, boolean> = {};
+  try {
+    const raw = localStorage.getItem('beaconTelemetryStaleMap');
+    if (raw) telemetryStaleMap = JSON.parse(raw);
+  } catch { /* ignore */ }
   const graceUntil = Number(localStorage.getItem('focusGraceUntil') || '0');
   const now = Date.now();
 
   if (cached) {
     const withStatus = (cached as any[]).map(b => {
       const prevOnline = statusMap[b.beaconID];
+      const prevStale = telemetryStaleMap[b.beaconID];
+      let result = b;
       if (prevOnline === true && b.online === false && now < graceUntil) {
-        return { ...b, online: true };
+        result = { ...result, online: true };
+      } else if (prevOnline !== undefined) {
+        result = { ...result, online: prevOnline };
       }
-      return prevOnline === undefined ? b : { ...b, online: prevOnline };
+      if (prevStale !== undefined) {
+        result = { ...result, telemetryStale: prevStale };
+      }
+      return result;
     });
     setBeacons(withStatus);
     setBeaconsLoaded(true);
@@ -49,10 +61,17 @@ export const fetchBeacons = async (setBeacons: any, setBeaconsLoaded: any) => {
     await db.put(STORE_NAME, beacons, 'beacons');
     const withStatus = (beacons as any[]).map(b => {
       const prevOnline = statusMap[b.beaconID];
+      const prevStale = telemetryStaleMap[b.beaconID];
+      let result = b;
       if (prevOnline === true && b.online === false && now < graceUntil) {
-        return { ...b, online: true };
+        result = { ...result, online: true };
+      } else if (prevOnline !== undefined) {
+        result = { ...result, online: prevOnline };
       }
-      return prevOnline === undefined ? b : { ...b, online: prevOnline };
+      if (prevStale !== undefined) {
+        result = { ...result, telemetryStale: prevStale };
+      }
+      return result;
     });
     setBeacons(withStatus);
     setBeaconsLoaded(true);

--- a/Web/web.client/src/components/BeaconMarker.test.ts
+++ b/Web/web.client/src/components/BeaconMarker.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { getBeaconVisualState } from './BeaconMarker';
+import type { Beacon } from '../types/Beacon';
+
+function makeBeacon(overrides: Partial<Beacon> = {}): Beacon {
+    return {
+        beaconID: '1',
+        beaconName: 'Test Beacon',
+        latitude: 43.0,
+        longitude: -88.0,
+        milepost: 100,
+        online: true,
+        railroadID: '1',
+        subdivisionID: '1',
+        telemetryStale: false,
+        ...overrides,
+    };
+}
+
+describe('getBeaconVisualState', () => {
+    describe('healthy beacon (online, telemetry fresh)', () => {
+        it('is not offline and not telemetry stale', () => {
+            const state = getBeaconVisualState(makeBeacon({ online: true, telemetryStale: false }));
+            expect(state.isOffline).toBe(false);
+            expect(state.isTelemetryStale).toBe(false);
+        });
+
+        it('uses blue dot color', () => {
+            const state = getBeaconVisualState(makeBeacon({ online: true, telemetryStale: false }));
+            expect(state.color).toBe('#005aa9');
+            expect(state.dotCenterColor).toBe('#005aa9');
+        });
+
+        it('reports title as online', () => {
+            const state = getBeaconVisualState(makeBeacon({ online: true, telemetryStale: false }));
+            expect(state.title).toBe('online');
+        });
+    });
+
+    describe('health-offline beacon (gray dot)', () => {
+        it('is offline regardless of telemetryStale flag', () => {
+            const state = getBeaconVisualState(makeBeacon({ online: false, telemetryStale: false }));
+            expect(state.isOffline).toBe(true);
+            expect(state.isTelemetryStale).toBe(false);
+        });
+
+        it('uses gray color', () => {
+            const state = getBeaconVisualState(makeBeacon({ online: false }));
+            expect(state.color).toBe('#888888');
+            expect(state.dotCenterColor).toBe('#888888');
+        });
+
+        it('reports title as offline', () => {
+            const state = getBeaconVisualState(makeBeacon({ online: false }));
+            expect(state.title).toBe('offline');
+        });
+
+        it('is never telemetry-stale when offline, even if telemetryStale is true', () => {
+            const state = getBeaconVisualState(makeBeacon({ online: false, telemetryStale: true }));
+            expect(state.isOffline).toBe(true);
+            expect(state.isTelemetryStale).toBe(false);
+        });
+    });
+
+    describe('telemetry-stale beacon (blue ring)', () => {
+        it('is telemetry stale when online and telemetryStale is true', () => {
+            const state = getBeaconVisualState(makeBeacon({ online: true, telemetryStale: true }));
+            expect(state.isOffline).toBe(false);
+            expect(state.isTelemetryStale).toBe(true);
+        });
+
+        it('uses blue outline color', () => {
+            const state = getBeaconVisualState(makeBeacon({ online: true, telemetryStale: true }));
+            expect(state.color).toBe('#005aa9');
+        });
+
+        it('uses dark theme center fill in dark map mode', () => {
+            const state = getBeaconVisualState(makeBeacon({ online: true, telemetryStale: true }), 'dark');
+            expect(state.dotCenterColor).toBe('#1a1a2e');
+        });
+
+        it('uses white center fill in light map mode', () => {
+            const state = getBeaconVisualState(makeBeacon({ online: true, telemetryStale: true }), 'light');
+            expect(state.dotCenterColor).toBe('#ffffff');
+        });
+
+        it('reports title as telemetry stale', () => {
+            const state = getBeaconVisualState(makeBeacon({ online: true, telemetryStale: true }));
+            expect(state.title).toBe('telemetry stale');
+        });
+    });
+
+    describe('theme-aware center fill only applies to telemetry-stale state', () => {
+        it('does not change dotCenterColor for healthy beacon in light mode', () => {
+            const state = getBeaconVisualState(makeBeacon({ online: true, telemetryStale: false }), 'light');
+            expect(state.dotCenterColor).toBe('#005aa9');
+        });
+
+        it('does not change dotCenterColor for offline beacon in light mode', () => {
+            const state = getBeaconVisualState(makeBeacon({ online: false }), 'light');
+            expect(state.dotCenterColor).toBe('#888888');
+        });
+    });
+});

--- a/Web/web.client/src/components/BeaconMarker.tsx
+++ b/Web/web.client/src/components/BeaconMarker.tsx
@@ -14,12 +14,32 @@ interface BeaconMarkerProps {
     pin: Beacon;
     zoom: number;
     idx: number;
+    mapTheme?: 'dark' | 'light';
 }
 
-const BeaconMarker: React.FC<BeaconMarkerProps> = ({ pin: beaconPin, zoom, idx }) => {
+export interface BeaconVisualState {
+    isOffline: boolean;
+    isTelemetryStale: boolean;
+    color: string;
+    dotCenterColor: string;
+    title: string;
+}
+
+export function getBeaconVisualState(beacon: Beacon, mapTheme: 'dark' | 'light' = 'dark'): BeaconVisualState {
+    const isOffline = beacon.online === false;
+    const isTelemetryStale = beacon.online !== false && beacon.telemetryStale === true;
+    const color = isOffline ? '#888888' : '#005aa9';
+    const dotCenterColor = isTelemetryStale
+        ? (mapTheme === 'dark' ? '#1a1a2e' : '#ffffff')
+        : color;
+    const title = isOffline ? 'offline' : isTelemetryStale ? 'telemetry stale' : 'online';
+    return { isOffline, isTelemetryStale, color, dotCenterColor, title };
+}
+
+const BeaconMarker: React.FC<BeaconMarkerProps> = ({ pin: beaconPin, zoom, idx, mapTheme = 'dark' }) => {
     const beaconName = beaconPin.beaconName;
-    const color = beaconPin.online === false ? '#888888' : '#005aa9';
-    const title = beaconPin.online === true ? 'online' : 'offline';
+    const { isOffline, isTelemetryStale, dotCenterColor, title } = getBeaconVisualState(beaconPin, mapTheme);
+
     const beaconDotSizePx = getBeaconDotSizePx(zoom);
 
     // Use metersToPixels for correct scaling
@@ -32,7 +52,8 @@ const BeaconMarker: React.FC<BeaconMarkerProps> = ({ pin: beaconPin, zoom, idx }
     // Ping base size so that at scale(10) it matches outlineSize
     const pingBaseSizePx = outlineSize / 10;
 
-    const dottedOutline = beaconPin.online === true
+    // Dotted outline: shown for healthy online beacons only
+    const dottedOutline = !isOffline && !isTelemetryStale
         ? `<div style="
             position:absolute;
             top:0;
@@ -48,8 +69,25 @@ const BeaconMarker: React.FC<BeaconMarkerProps> = ({ pin: beaconPin, zoom, idx }
         "></div>`
         : '';
 
-    // Ping is absolutely centered and animates to match outline
-    const pingDiv = beaconPin.online !== false
+    // Blue ring: shown for telemetry-stale beacons (solid ring, no ping)
+    const telemetryStaleRing = isTelemetryStale
+        ? `<div style="
+            position:absolute;
+            top:0;
+            left:0;
+            width:${outlineSize}px;
+            height:${outlineSize}px;
+            border-radius:50%;
+            border:3px solid #005aa9;
+            box-sizing:border-box;
+            pointer-events:none;
+            z-index:1;
+            cursor: default;
+        "></div>`
+        : '';
+
+    // Ping animation: shown for healthy online beacons only
+    const pingDiv = !isOffline && !isTelemetryStale
         ? `<div class=\"beacon-ping\" style=\"
             position:absolute;
             top:50%;
@@ -76,10 +114,11 @@ const BeaconMarker: React.FC<BeaconMarkerProps> = ({ pin: beaconPin, zoom, idx }
                 html: `
                     <div class=\"beacon-container\" style=\"position: relative; width: ${outlineSize}px; height: ${outlineSize}px; pointer-events: none;\">
                         ${dottedOutline}
+                        ${telemetryStaleRing}
                         <div class=\"beacon-dot\" title=\"${beaconName} ${title}\" style=\"
                             width:${beaconDotSizePx}px;
                             height:${beaconDotSizePx}px;
-                            background:${color};
+                            background:${dotCenterColor};
                             border-radius:50%;
                             position:absolute;
                             top:${beaconDotOffsetPx}px;
@@ -87,6 +126,7 @@ const BeaconMarker: React.FC<BeaconMarkerProps> = ({ pin: beaconPin, zoom, idx }
                             z-index:2;
                             pointer-events: auto;
                             cursor: pointer;
+                            ${isTelemetryStale ? `border: 2px solid #005aa9;` : ''}
                         \" ></div>
                         ${pingDiv}
                     </div>

--- a/Web/web.client/src/components/BeaconMarkers.tsx
+++ b/Web/web.client/src/components/BeaconMarkers.tsx
@@ -117,6 +117,7 @@ const BeaconMarkers: React.FC<BeaconMarkersProps> = ({
                             pin={beaconPin}
                             zoom={zoom}
                             idx={idx}
+                            mapTheme={mapTheme}
                         />
                         {zoom >= LABEL_ZOOM_THRESHOLD && (
                             <BeaconLabelPin

--- a/Web/web.client/src/hooks/useBeacons.ts
+++ b/Web/web.client/src/hooks/useBeacons.ts
@@ -95,7 +95,8 @@ export function useBeacons() {
           latitude: b.latitude,
           longitude: b.longitude,
           milepost: b.milepost,
-          online: b.online
+          online: b.online,
+          telemetryStale: b.telemetryStale
         }));
         
         // Store beacons and cache version together

--- a/Web/web.client/src/hooks/useBeacons.ts
+++ b/Web/web.client/src/hooks/useBeacons.ts
@@ -11,6 +11,11 @@ export function useBeacons() {
     const raw = localStorage.getItem('beaconStatusMap');
     if (raw) initialStatusMap = JSON.parse(raw);
   } catch { /* ignore malformed storage */ }
+  let initialStaleMap: Record<string, boolean> = {};
+  try {
+    const raw = localStorage.getItem('beaconTelemetryStaleMap');
+    if (raw) initialStaleMap = JSON.parse(raw);
+  } catch { /* ignore malformed storage */ }
 
   useEffect(() => {
     const fetchBeacons = async () => {
@@ -64,10 +69,17 @@ export function useBeacons() {
       if (cached) {
         const withStatus = (cached as Beacon[]).map(b => {
           const stored = initialStatusMap[b.beaconID];
+          const storedStale = initialStaleMap[b.beaconID];
+          let result = b;
           if (stored === true && b.online === false && now < graceUntil) {
-            return { ...b, online: true };
+            result = { ...result, online: true };
+          } else if (stored !== undefined) {
+            result = { ...result, online: stored };
           }
-          return stored === undefined ? b : { ...b, online: stored };
+          if (storedStale !== undefined) {
+            result = { ...result, telemetryStale: storedStale };
+          }
+          return result;
         });
         setBeacons(withStatus);
         setBeaconsLoaded(true);
@@ -105,10 +117,17 @@ export function useBeacons() {
         
         const withStatus = (beacons as Beacon[]).map(b => {
           const stored = initialStatusMap[b.beaconID];
+          const storedStale = initialStaleMap[b.beaconID];
+          let result = b;
           if (stored === true && b.online === false && now < graceUntil) {
-            return { ...b, online: true };
+            result = { ...result, online: true };
+          } else if (stored !== undefined) {
+            result = { ...result, online: stored };
           }
-          return stored === undefined ? b : { ...b, online: stored };
+          if (storedStale !== undefined) {
+            result = { ...result, telemetryStale: storedStale };
+          }
+          return result;
         });
         setBeacons(withStatus);
         setBeaconsLoaded(true);
@@ -123,8 +142,17 @@ export function useBeacons() {
   useEffect(() => {
     if (!beacons.length) return;
     const statusMap: Record<string, boolean> = {};
-    beacons.forEach(b => { if (b && b.beaconID) statusMap[b.beaconID] = !!b.online; });
-    try { localStorage.setItem('beaconStatusMap', JSON.stringify(statusMap)); } catch { /* ignore quota */ }
+    const staleMap: Record<string, boolean> = {};
+    beacons.forEach(b => {
+      if (b && b.beaconID) {
+        statusMap[b.beaconID] = !!b.online;
+        staleMap[b.beaconID] = !!b.telemetryStale;
+      }
+    });
+    try {
+      localStorage.setItem('beaconStatusMap', JSON.stringify(statusMap));
+      localStorage.setItem('beaconTelemetryStaleMap', JSON.stringify(staleMap));
+    } catch { /* ignore quota */ }
   }, [beacons]);
 
   return { beacons, beaconsLoaded, setBeacons };

--- a/Web/web.client/src/hooks/useBeacons.ts
+++ b/Web/web.client/src/hooks/useBeacons.ts
@@ -23,7 +23,7 @@ export function useBeacons() {
       const DB_VERSION = 2;
       // Cache schema version - increment when beacon data structure changes
       // This ensures stale cached data without new fields (like railroad/subdivision names) is refreshed
-      const BEACON_CACHE_VERSION = 2; // v2: added railroad/subdivision name fields
+      const BEACON_CACHE_VERSION = 3; // v3: telemetryStale fix — invalidate caches written while the backend always returned false
       const CACHE_VERSION_KEY = 'beacons_version';
       
       const db = await openDB('railways-db', DB_VERSION, {

--- a/Web/web.client/src/types/AdminBeaconRailroad.ts
+++ b/Web/web.client/src/types/AdminBeaconRailroad.ts
@@ -11,6 +11,7 @@ export interface AdminBeaconRailroad {
   multipleTracks: boolean;
   online: boolean;
   direction: Direction;
+  telemetryStaleHoursOverride?: number | null;
 }
 
 export type Direction = 'All' | 'NorthSouth' | 'EastWest' | 'NortheastSouthwest' | 'NorthwestSoutheast';
@@ -24,6 +25,7 @@ export interface CreateBeaconRailroad {
   multipleTracks: boolean;
   online: boolean;
   direction: Direction;
+  telemetryStaleHoursOverride?: number | null;
 }
 
 export interface UpdateBeaconRailroad {
@@ -35,4 +37,5 @@ export interface UpdateBeaconRailroad {
   multipleTracks: boolean;
   online: boolean;
   direction: Direction;
+  telemetryStaleHoursOverride?: number | null;
 }

--- a/Web/web.client/src/types/Beacon.ts
+++ b/Web/web.client/src/types/Beacon.ts
@@ -9,4 +9,5 @@ export type Beacon = {
     longitude: number;
     milepost: number;
     online: boolean; // primitive boolean for reliable equality checks & persistence
+    telemetryStale?: boolean; // true when health endpoint is pinging but telemetry is stale past threshold
 };

--- a/Web/web.client/src/views/AdminBeaconRailroads.test.ts
+++ b/Web/web.client/src/views/AdminBeaconRailroads.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { validateTelemetryStaleHoursOverride } from './AdminBeaconRailroads';
+
+describe('validateTelemetryStaleHoursOverride', () => {
+  it('returns null for null (no override)', () => {
+    expect(validateTelemetryStaleHoursOverride(null)).toBeNull();
+  });
+
+  it('returns null for undefined (no override)', () => {
+    expect(validateTelemetryStaleHoursOverride(undefined)).toBeNull();
+  });
+
+  it('returns null for a valid positive integer', () => {
+    expect(validateTelemetryStaleHoursOverride(6)).toBeNull();
+    expect(validateTelemetryStaleHoursOverride(1)).toBeNull();
+    expect(validateTelemetryStaleHoursOverride(24)).toBeNull();
+  });
+
+  it('returns an error for zero', () => {
+    const error = validateTelemetryStaleHoursOverride(0);
+    expect(error).toBe('Telemetry stale hours override must be a whole integer greater than zero');
+  });
+
+  it('returns an error for a negative value', () => {
+    const error = validateTelemetryStaleHoursOverride(-1);
+    expect(error).toBe('Telemetry stale hours override must be a whole integer greater than zero');
+  });
+
+  it('returns an error for a non-integer (float)', () => {
+    const error = validateTelemetryStaleHoursOverride(1.5);
+    expect(error).toBe('Telemetry stale hours override must be a whole integer greater than zero');
+  });
+
+  it('returns an error for a negative float', () => {
+    const error = validateTelemetryStaleHoursOverride(-0.5);
+    expect(error).toBe('Telemetry stale hours override must be a whole integer greater than zero');
+  });
+});

--- a/Web/web.client/src/views/AdminBeaconRailroads.tsx
+++ b/Web/web.client/src/views/AdminBeaconRailroads.tsx
@@ -19,6 +19,18 @@ type SortDirection = 'asc' | 'desc' | null;
 
 const DIRECTION_OPTIONS: Direction[] = ['All', 'NorthSouth', 'EastWest', 'NortheastSouthwest', 'NorthwestSoutheast'];
 
+/**
+ * Validates the optional telemetryStaleHoursOverride value.
+ * Returns an error string if invalid, or null if valid (including when the value is null/undefined).
+ */
+export function validateTelemetryStaleHoursOverride(value: number | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  if (!Number.isInteger(value) || value <= 0) {
+    return 'Telemetry stale hours override must be a whole integer greater than zero';
+  }
+  return null;
+}
+
 const AdminBeaconRailroads = () => {
   const [beaconRailroads, setBeaconRailroads] = useState<AdminBeaconRailroad[]>([]);
   const [beacons, setBeacons] = useState<AdminBeacon[]>([]);
@@ -35,7 +47,8 @@ const AdminBeaconRailroads = () => {
     milepost: 0,
     multipleTracks: false,
     online: true,
-    direction: 'All'
+    direction: 'All',
+    telemetryStaleHoursOverride: null
   });
   const [searchTerm, setSearchTerm] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
@@ -145,7 +158,8 @@ const AdminBeaconRailroads = () => {
       milepost: 0,
       multipleTracks: false,
       online: true,
-      direction: 'All'
+      direction: 'All',
+      telemetryStaleHoursOverride: null
     });
     setError(undefined);
     setShowModal(true);
@@ -161,7 +175,8 @@ const AdminBeaconRailroads = () => {
       milepost: beaconRailroad.milepost,
       multipleTracks: beaconRailroad.multipleTracks,
       online: beaconRailroad.online,
-      direction: beaconRailroad.direction
+      direction: beaconRailroad.direction,
+      telemetryStaleHoursOverride: beaconRailroad.telemetryStaleHoursOverride ?? null
     });
     setError(undefined);
     setShowModal(true);
@@ -201,6 +216,12 @@ const AdminBeaconRailroads = () => {
 
     if (formData.longitude < -180 || formData.longitude > 180) {
       setError('Longitude must be between -180 and 180');
+      return;
+    }
+
+    const overrideError = validateTelemetryStaleHoursOverride(formData.telemetryStaleHoursOverride);
+    if (overrideError) {
+      setError(overrideError);
       return;
     }
 
@@ -460,6 +481,25 @@ const AdminBeaconRailroads = () => {
                   />
                   Multiple Tracks
                 </label>
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="telemetryStaleHoursOverride">Telemetry Stale Hours Override (optional)</label>
+                <input
+                  id="telemetryStaleHoursOverride"
+                  type="number"
+                  min="1"
+                  step="1"
+                  value={formData.telemetryStaleHoursOverride ?? ''}
+                  onChange={(e) => {
+                    const raw = e.target.value;
+                    setFormData({
+                      ...formData,
+                      telemetryStaleHoursOverride: raw === '' ? null : parseInt(raw, 10)
+                    });
+                  }}
+                  placeholder="Leave blank to use default (6 hours)"
+                />
               </div>
 
               <div className="form-actions">

--- a/Web/web.client/src/views/AdminTelemetryLog.tsx
+++ b/Web/web.client/src/views/AdminTelemetryLog.tsx
@@ -233,7 +233,8 @@ function AdminTelemetryLog() {
         {
             field: 'discarded',
             headerName: 'Discarded',
-            width: 170,
+            width: 300,
+            flex: 1,
             renderCell: (params: any) => {
                 const reason = params.row?.discardReason;
                 if (reason && reason.trim()) {

--- a/Web/web.client/src/views/RailMap.tsx
+++ b/Web/web.client/src/views/RailMap.tsx
@@ -285,7 +285,8 @@ const RailMap: React.FC = () => {
                         latitude: b.latitude,
                         longitude: b.longitude,
                         milepost: b.milepost,
-                        online: b.online
+                        online: b.online,
+                        telemetryStale: b.telemetryStale
                     };
                     // Filter out beacons with invalid IDs (0 or null/undefined)
                     if (mappedBeacon.beaconID && Number(mappedBeacon.beaconID) !== 0 && mappedBeacon.railroadID && Number(mappedBeacon.railroadID) !== 0) {


### PR DESCRIPTION
## Summary
- migrate the configurable beacon telemetry-stale hours feature onto a clean branch
- include admin control for telemetry-stale hours override
- include offline indicator updates for beacon markers

## Issue
Closes #59

## Notes
- branch excludes generated NuGet/obj artifact commits that caused history issues