### PR TITLE
Fix: beacons with no telemetry history exempted from stale state

### DIFF
--- a/Web/Web.Server/Services/BeaconRailroadHealthService.cs
+++ b/Web/Web.Server/Services/BeaconRailroadHealthService.cs
@@ -92,9 +92,10 @@ namespace Web.Server.Services
                     }
                     else
                     {
-                        // No train passage recorded for this beacon/subdivision within the
-                        // MapPinHistories retention window — not considered stale
-                        beaconRailroadDTO.TelemetryStale = false;
+                        // No train passage ever recorded for this beacon/subdivision — that
+                        // trivially satisfies "no telemetry within the effective threshold",
+                        // so it must be reported stale rather than exempted.
+                        beaconRailroadDTO.TelemetryStale = true;
                     }
                 }
                 else

--- a/Web/Web.ServerTests/Services/BeaconRailroadHealthServiceTests.cs
+++ b/Web/Web.ServerTests/Services/BeaconRailroadHealthServiceTests.cs
@@ -273,10 +273,13 @@ namespace Web.ServerTests.Services
         }
 
         [TestMethod]
-        public void StateClassification_NoTelemetryEver_NotConsideredStale()
+        public void StateClassification_NoTelemetryEver_IsConsideredStale()
         {
-            // Beacon: health fresh, but no telemetry records at all → TelemetryStale = false
-            var dbName = nameof(StateClassification_NoTelemetryEver_NotConsideredStale);
+            // Beacon: health fresh, but no telemetry records at all → TelemetryStale = true.
+            // Zero telemetry ever trivially satisfies "no telemetry within the effective
+            // threshold", so a beacon that has never seen a train (e.g. newly installed,
+            // or on a subdivision with no MapPinHistories rows) must not be exempted.
+            var dbName = nameof(StateClassification_NoTelemetryEver_IsConsideredStale);
             using var dbContext = CreateInMemoryDbContext(dbName);
 
             // Add beacon railroad with no telemetry
@@ -320,7 +323,7 @@ namespace Web.ServerTests.Services
 
             var dto = sentDTOs.First(d => d.BeaconID == 1);
             Assert.IsTrue(dto.Online, "Beacon should be online");
-            Assert.IsFalse(dto.TelemetryStale, "TelemetryStale should be false when no telemetry ever received");
+            Assert.IsTrue(dto.TelemetryStale, "TelemetryStale should be true when no telemetry has ever been received");
         }
 
         // ── TelemetryStaleHoursOverride passthrough in DTO ────────────────────


### PR DESCRIPTION
## Summary
- `BeaconRailroadHealthService` exempted beacons with zero `MapPinHistories` rows (no train has ever passed) from `TelemetryStale`, so they rendered as a solid healthy dot indefinitely.
- Zero telemetry ever trivially satisfies "no telemetry within the effective threshold," so it should be reported stale like any other beacon past its threshold — not exempted.

## Change
- `BeaconRailroadHealthService.cs`: the "no MapPinHistories row found" branch now sets `TelemetryStale = true` instead of `false`.
- Updated `BeaconRailroadHealthServiceTests.cs`'s corresponding test to assert the new expected behavior.

## Test plan
- [x] `dotnet test Web/Web.ServerTests` — 153 passed, 1 pre-existing unrelated skip, 0 failed
- [x] Verified against a real beacon (Dale/CN) with no history that previously showed solid blue

🤖 Generated with [Claude Code](https://claude.com/claude-code)