### PR TITLE
Add offline notes for beacon railroads

### DIFF
--- a/Web/Web.Server/Controllers/v1/BeaconRailroadsController.cs
+++ b/Web/Web.Server/Controllers/v1/BeaconRailroadsController.cs
@@ -1,6 +1,8 @@
 using MapsterMapper;
 using Microsoft.AspNetCore.Mvc;
 using Web.Server.DTOs;
+using Web.Server.Entities;
+using Web.Server.Providers;
 using Web.Server.Services;
 
 namespace Web.Server.Controllers.v1
@@ -10,12 +12,21 @@ namespace Web.Server.Controllers.v1
     public class BeaconRailroadsController : ControllerBase
     {
         private readonly IBeaconRailroadService _service;
+        private readonly IUserService _userService;
+        private readonly ITimeProvider _timeProvider;
         private readonly ILogger<BeaconRailroadsController> _logger;
         private readonly IMapper _mapper;
 
-        public BeaconRailroadsController(IBeaconRailroadService service, ILogger<BeaconRailroadsController> logger, IMapper mapper)
+        public BeaconRailroadsController(
+            IBeaconRailroadService service,
+            IUserService userService,
+            ITimeProvider timeProvider,
+            ILogger<BeaconRailroadsController> logger,
+            IMapper mapper)
         {
             _service = service;
+            _userService = userService;
+            _timeProvider = timeProvider;
             _logger = logger;
             _mapper = mapper;
         }
@@ -27,8 +38,13 @@ namespace Web.Server.Controllers.v1
             try
             {
                 var beaconRailroads = await _service.GetAllAsync();
-                var beaconRailroadDTO = _mapper.Map<IEnumerable<BeaconRailroadDTO>>(beaconRailroads);
-                response.Data = beaconRailroadDTO;
+                var beaconRailroadDTOs = _mapper.Map<IEnumerable<BeaconRailroadDTO>>(beaconRailroads).ToList();
+                var utcNow = _timeProvider.UtcNow;
+                foreach (var dto in beaconRailroadDTOs)
+                {
+                    dto.Online = !BeaconRailroadHealthService.IsOffline(dto.LastUpdate, utcNow);
+                }
+                response.Data = beaconRailroadDTOs;
                 return Ok(response);
             }
             catch (Exception ex)
@@ -52,6 +68,7 @@ namespace Web.Server.Controllers.v1
                 }
 
                 var beaconRailroadDTO = _mapper.Map<BeaconRailroadDTO>(beaconRailroad);
+                beaconRailroadDTO.Online = !BeaconRailroadHealthService.IsOffline(beaconRailroadDTO.LastUpdate, _timeProvider.UtcNow);
                 response.Data = beaconRailroadDTO;
 
                 return Ok(response);
@@ -70,6 +87,12 @@ namespace Web.Server.Controllers.v1
             var response = new MessageEnvelope<BeaconRailroadDTO>(null, []);
             try
             {
+                if (!await IsAdminAsync())
+                {
+                    response.Errors.Add("Forbidden.");
+                    return StatusCode(StatusCodes.Status403Forbidden, response);
+                }
+
                 if (dto.TelemetryStaleHoursOverride.HasValue && dto.TelemetryStaleHoursOverride.Value <= 0)
                 {
                     response.Errors.Add("TelemetryStaleHoursOverride must be a whole integer greater than zero when provided.");
@@ -114,9 +137,78 @@ namespace Web.Server.Controllers.v1
                     return BadRequest(response);
                 }
 
-                var beaconRailroad = _mapper.Map<Entities.BeaconRailroad>(dto);
-                beaconRailroad.BeaconID = beaconId;  // Ensure composite key is set
-                beaconRailroad.SubdivisionID = subdivisionId;
+                var currentUser = await GetCurrentUserAsync();
+                if (currentUser == null)
+                {
+                    response.Errors.Add("Forbidden.");
+                    return StatusCode(StatusCodes.Status403Forbidden, response);
+                }
+
+                var existingBeaconRailroad = await _service.GetByIdAsync(beaconId, subdivisionId);
+                if (existingBeaconRailroad == null)
+                {
+                    response.Errors.Add("BeaconRailroad not found.");
+                    return NotFound(response);
+                }
+
+                if (!string.IsNullOrEmpty(dto.OfflineNote))
+                {
+                    var latestTelemetry = await _service.GetLatestTelemetryTimestampAsync(beaconId, subdivisionId);
+                    var isTrulyOffline = BeaconRailroadHealthService.IsTrulyOffline(
+                        existingBeaconRailroad.LastUpdate, latestTelemetry, _timeProvider.UtcNow);
+
+                    if (!isTrulyOffline)
+                    {
+                        response.Errors.Add("Cannot set an offline note on a beacon railroad that is currently online.");
+                        return BadRequest(response);
+                    }
+                }
+
+                var isAdmin = HasRole(currentUser, "Admin");
+                Entities.BeaconRailroad beaconRailroad;
+
+                if (isAdmin)
+                {
+                    beaconRailroad = _mapper.Map<Entities.BeaconRailroad>(dto);
+                    beaconRailroad.BeaconID = beaconId;  // Ensure composite key is set
+                    beaconRailroad.SubdivisionID = subdivisionId;
+                }
+                else
+                {
+                    var isCustodian = HasRole(currentUser, "Custodian");
+                    if (!isCustodian || existingBeaconRailroad.Subdivision?.CustodianId != currentUser.ID)
+                    {
+                        response.Errors.Add("Forbidden.");
+                        return StatusCode(StatusCodes.Status403Forbidden, response);
+                    }
+
+                    var changedReadOnlyFields =
+                        dto.Latitude != existingBeaconRailroad.Latitude ||
+                        dto.Longitude != existingBeaconRailroad.Longitude ||
+                        dto.Milepost != existingBeaconRailroad.Milepost ||
+                        dto.MultipleTracks != existingBeaconRailroad.MultipleTracks ||
+                        dto.Direction != existingBeaconRailroad.Direction ||
+                        dto.TelemetryStaleHoursOverride != existingBeaconRailroad.TelemetryStaleHoursOverride;
+
+                    if (changedReadOnlyFields)
+                    {
+                        response.Errors.Add("Custodians can only update OfflineNote for their assigned subdivision's beacon railroads.");
+                        return StatusCode(StatusCodes.Status403Forbidden, response);
+                    }
+
+                    beaconRailroad = new Entities.BeaconRailroad
+                    {
+                        BeaconID = beaconId,
+                        SubdivisionID = subdivisionId,
+                        Direction = existingBeaconRailroad.Direction,
+                        Latitude = existingBeaconRailroad.Latitude,
+                        Longitude = existingBeaconRailroad.Longitude,
+                        Milepost = existingBeaconRailroad.Milepost,
+                        MultipleTracks = existingBeaconRailroad.MultipleTracks,
+                        TelemetryStaleHoursOverride = existingBeaconRailroad.TelemetryStaleHoursOverride,
+                        OfflineNote = dto.OfflineNote
+                    };
+                }
 
                 await _service.UpdateAsync(beaconRailroad);
 
@@ -135,6 +227,11 @@ namespace Web.Server.Controllers.v1
         {
             try
             {
+                if (!await IsAdminAsync())
+                {
+                    return StatusCode(StatusCodes.Status403Forbidden);
+                }
+
                 var deleted = await _service.DeleteAsync(beaconId, subdivisionId);
                 if (!deleted)
                 {
@@ -148,6 +245,28 @@ namespace Web.Server.Controllers.v1
                 _logger.LogError(ex, "An error occurred while deleting beacon railroad {BeaconId}/{SubdivisionId}.", beaconId, subdivisionId);
                 return StatusCode(StatusCodes.Status500InternalServerError, new MessageEnvelope<object>(null, new List<string> { ex.Message }));
             }
+        }
+
+        private async Task<bool> IsAdminAsync()
+        {
+            var user = await GetCurrentUserAsync();
+            return user != null && HasRole(user, "Admin");
+        }
+
+        private async Task<User?> GetCurrentUserAsync()
+        {
+            if (!HttpContext.Items.TryGetValue("UserId", out var userIdObj) || userIdObj is not int userId)
+            {
+                return null;
+            }
+
+            return await _userService.GetUserByIdAsync(userId);
+        }
+
+        private static bool HasRole(User user, string roleName)
+        {
+            return user.UserRoles?.Any(ur =>
+                string.Equals(ur.Role?.RoleName, roleName, StringComparison.OrdinalIgnoreCase)) == true;
         }
     }
 }

--- a/Web/Web.Server/DTOs/BeaconRailroadDTO.cs
+++ b/Web/Web.Server/DTOs/BeaconRailroadDTO.cs
@@ -81,6 +81,12 @@ namespace Web.Server.DTOs
         public int? TelemetryStaleHoursOverride { get; set; }
 
         /// <summary>
+        /// Free-text note explaining why this beacon railroad is currently offline.
+        /// Null when the beacon railroad is online or no note has been set.
+        /// </summary>
+        public string? OfflineNote { get; set; }
+
+        /// <summary>
         /// The direction in which telemetry data is moving.
         /// </summary>
         /// <example>NorthSouth</example>
@@ -113,6 +119,7 @@ namespace Web.Server.DTOs
                    Online == other.Online &&
                    TelemetryStale == other.TelemetryStale &&
                    TelemetryStaleHoursOverride == other.TelemetryStaleHoursOverride &&
+                   OfflineNote == other.OfflineNote &&
                    Direction == other.Direction &&
                    CreatedAt == other.CreatedAt &&
                    LastUpdate == other.LastUpdate;
@@ -130,6 +137,7 @@ namespace Web.Server.DTOs
             hash.Add(Online);
             hash.Add(TelemetryStale);
             hash.Add(TelemetryStaleHoursOverride);
+            hash.Add(OfflineNote);
             hash.Add(Direction);
             hash.Add(CreatedAt);
             hash.Add(LastUpdate);

--- a/Web/Web.Server/DTOs/UpdateBeaconRailroadDTO.cs
+++ b/Web/Web.Server/DTOs/UpdateBeaconRailroadDTO.cs
@@ -6,6 +6,13 @@ namespace Web.Server.DTOs
 
         public int SubdivisionID { get; set; }
 
+        /// <summary>
+        /// Free-text note explaining why this beacon railroad is currently offline.
+        /// Only settable while the beacon railroad is offline; automatically cleared
+        /// when it comes back online.
+        /// </summary>
+        public string? OfflineNote { get; set; }
+
         public override bool Equals(object? obj)
         {
             return Equals(obj as UpdateBeaconRailroadDTO);
@@ -23,6 +30,7 @@ namespace Web.Server.DTOs
                    MultipleTracks == other.MultipleTracks &&
                    Online == other.Online &&
                    Direction == other.Direction &&
+                   OfflineNote == other.OfflineNote &&
                    BeaconID == other.BeaconID &&
                    SubdivisionID == other.SubdivisionID;
         }
@@ -39,6 +47,7 @@ namespace Web.Server.DTOs
             hash.Add(MultipleTracks);
             hash.Add(Online);
             hash.Add(Direction);
+            hash.Add(OfflineNote);
             hash.Add(BeaconID);
             hash.Add(SubdivisionID);
             return hash.ToHashCode();

--- a/Web/Web.Server/Entities/BeaconRailroad.cs
+++ b/Web/Web.Server/Entities/BeaconRailroad.cs
@@ -41,6 +41,13 @@ namespace Web.Server.Entities
         /// </summary>
         public int? TelemetryStaleHoursOverride { get; set; }
 
+        /// <summary>
+        /// Free-text note explaining why this beacon railroad is currently offline.
+        /// Only settable while the beacon railroad is offline; automatically cleared
+        /// when it comes back online (health check or telemetry received).
+        /// </summary>
+        public string? OfflineNote { get; set; }
+
         public override bool Equals(object? obj)
         {
             return Equals(obj as BeaconRailroad);
@@ -61,7 +68,8 @@ namespace Web.Server.Entities
                    EqualityComparer<ICollection<MapPin>>.Default.Equals(MapPins, other.MapPins) &&
                    Milepost == other.Milepost &&
                    MultipleTracks == other.MultipleTracks &&
-                   TelemetryStaleHoursOverride == other.TelemetryStaleHoursOverride;
+                   TelemetryStaleHoursOverride == other.TelemetryStaleHoursOverride &&
+                   OfflineNote == other.OfflineNote;
         }
 
         public override int GetHashCode()
@@ -80,6 +88,7 @@ namespace Web.Server.Entities
             hash.Add(Milepost);
             hash.Add(MultipleTracks);
             hash.Add(TelemetryStaleHoursOverride);
+            hash.Add(OfflineNote);
             return hash.ToHashCode();
         }
 

--- a/Web/Web.Server/Migrations/20260726222935_AddOfflineNoteToBeaconRailroad.Designer.cs
+++ b/Web/Web.Server/Migrations/20260726222935_AddOfflineNoteToBeaconRailroad.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Web.Server.Data;
 
@@ -10,9 +11,11 @@ using Web.Server.Data;
 namespace Web.Server.Migrations
 {
     [DbContext(typeof(TelemetryDbContext))]
-    partial class TelemetryDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260726222935_AddOfflineNoteToBeaconRailroad")]
+    partial class AddOfflineNoteToBeaconRailroad
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.4");

--- a/Web/Web.Server/Migrations/20260726222935_AddOfflineNoteToBeaconRailroad.cs
+++ b/Web/Web.Server/Migrations/20260726222935_AddOfflineNoteToBeaconRailroad.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Web.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOfflineNoteToBeaconRailroad : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "OfflineNote",
+                table: "BeaconRailroads",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OfflineNote",
+                table: "BeaconRailroads");
+        }
+    }
+}

--- a/Web/Web.Server/Repositories/BeaconRailroadRepository.cs
+++ b/Web/Web.Server/Repositories/BeaconRailroadRepository.cs
@@ -60,12 +60,23 @@ namespace Web.Server.Repositories
             existing.Milepost = beaconRailroad.Milepost;
             existing.MultipleTracks = beaconRailroad.MultipleTracks;
             existing.TelemetryStaleHoursOverride = beaconRailroad.TelemetryStaleHoursOverride;
-            existing.LastUpdate = _timeProvider.UtcNow;
+            existing.OfflineNote = beaconRailroad.OfflineNote;
+            // LastUpdate is reserved for actual health-check pings (BeaconService.UpdateBeaconHealthAsync)
+            // and is the sole signal the health service uses to determine online/offline. Bumping it here
+            // on ordinary metadata edits would spuriously revive an offline beacon railroad as "online".
 
             await _context.SaveChangesAsync();
 
             // Re-query with all necessary includes for a fully hydrated object
             return await GetByIdAsync(beaconRailroad.BeaconID, beaconRailroad.SubdivisionID);
+        }
+
+        public async Task<DateTime?> GetLatestTelemetryTimestampAsync(int beaconId, int subdivisionId)
+        {
+            return await _context.MapPinHistories
+                .Where(mph => mph.BeaconID == beaconId && mph.SubdivisionId == subdivisionId)
+                .Select(mph => (DateTime?)mph.LastUpdate)
+                .MaxAsync();
         }
 
         public async Task<bool> DeleteAsync(int beaconId, int railroadId)

--- a/Web/Web.Server/Repositories/IBeaconRailroadRepository.cs
+++ b/Web/Web.Server/Repositories/IBeaconRailroadRepository.cs
@@ -9,5 +9,6 @@ namespace Web.Server.Repositories
         Task<BeaconRailroad?> GetByIdAsync(int beaconId, int subdivisionId);
         Task<BeaconRailroad> UpdateAsync(BeaconRailroad beaconRailroad);
         Task<bool> DeleteAsync(int beaconId, int railroadId);
+        Task<DateTime?> GetLatestTelemetryTimestampAsync(int beaconId, int subdivisionId);
     }
 }

--- a/Web/Web.Server/Services/BeaconRailroadHealthService.cs
+++ b/Web/Web.Server/Services/BeaconRailroadHealthService.cs
@@ -9,6 +9,8 @@ namespace Web.Server.Services
 {
     public class BeaconRailroadHealthService : BackgroundService
     {
+        public const int HealthCutoffMinutes = 15;
+
         private readonly TimeSpan _cleanupInterval = TimeSpan.FromMinutes(1);
 
         private readonly IHubContext<NotificationHub> _hubContext;
@@ -50,13 +52,15 @@ namespace Web.Server.Services
         /// </summary>
         protected internal async Task ComputeAndSendBeaconStatusAsync(TelemetryDbContext dbContext, CancellationToken cancellationToken)
         {
-            var healthCutoff = DateTime.UtcNow.AddMinutes(-15);
+            var utcNow = DateTime.UtcNow;
 
             var beaconRailroads = dbContext.BeaconRailroads
                 .Include(br => br.Beacon)
                 .Include(br => br.Subdivision)
                     .ThenInclude(s => s.Railroad)
                 .ToList();
+
+            var beaconRailroadsByKey = beaconRailroads.ToDictionary(br => (br.BeaconID, br.SubdivisionID));
 
             // Build a map of (BeaconID, SubdivisionID) -> most recent train-passage timestamp.
             // Sourced from MapPinHistories rather than Telemetries: raw Telemetries rows are
@@ -74,19 +78,34 @@ namespace Web.Server.Services
             var beaconRailroadDTOs = _mapper.Map<IEnumerable<BeaconRailroadDTO>>(beaconRailroads);
 
             var updatedBeacons = new List<BeaconRailroadDTO>();
+            var notesCleared = false;
 
             foreach (var beaconRailroadDTO in beaconRailroadDTOs)
             {
-                var isOffline = beaconRailroadDTO.LastUpdate != default && beaconRailroadDTO.LastUpdate <= healthCutoff;
+                var isOffline = IsOffline(beaconRailroadDTO.LastUpdate, utcNow);
 
                 beaconRailroadDTO.Online = !isOffline;
+
+                var entity = beaconRailroadsByKey[(beaconRailroadDTO.BeaconID, beaconRailroadDTO.SubdivisionID)];
+
+                var hasTelemetryRecord = latestTelemetryByBeaconSubdivision.TryGetValue(
+                    (beaconRailroadDTO.BeaconID, beaconRailroadDTO.SubdivisionID), out var lastTelemetryTime);
+                var latestTelemetry = hasTelemetryRecord ? lastTelemetryTime : (DateTime?)null;
+
+                var isTrulyOffline = IsTrulyOffline(beaconRailroadDTO.LastUpdate, latestTelemetry, utcNow);
+                if (!isTrulyOffline && entity.OfflineNote != null)
+                {
+                    entity.OfflineNote = null;
+                    notesCleared = true;
+                }
+                beaconRailroadDTO.OfflineNote = entity.OfflineNote;
 
                 if (beaconRailroadDTO.Online)
                 {
                     var effectiveThresholdHours = beaconRailroadDTO.TelemetryStaleHoursOverride ?? _telemetryStaleHoursDefault;
-                    var telemetryCutoff = DateTime.UtcNow.AddHours(-effectiveThresholdHours);
+                    var telemetryCutoff = utcNow.AddHours(-effectiveThresholdHours);
 
-                    if (latestTelemetryByBeaconSubdivision.TryGetValue((beaconRailroadDTO.BeaconID, beaconRailroadDTO.SubdivisionID), out var lastTelemetryTime))
+                    if (hasTelemetryRecord)
                     {
                         beaconRailroadDTO.TelemetryStale = lastTelemetryTime <= telemetryCutoff;
                     }
@@ -106,11 +125,39 @@ namespace Web.Server.Services
                 updatedBeacons.Add(beaconRailroadDTO);
             }
 
+            if (notesCleared)
+            {
+                await dbContext.SaveChangesAsync(cancellationToken);
+            }
+
             // Send all beacons as a single batch to match frontend expectation of Beacon[]
             if (updatedBeacons.Any())
             {
                 await _hubContext.Clients.All.SendAsync(NotificationMethods.BeaconUpdate, updatedBeacons, cancellationToken: cancellationToken);
             }
+        }
+
+        /// <summary>
+        /// Shared "is offline" rule used by both this background service and
+        /// BeaconRailroadsController (to gate when an OfflineNote may be set).
+        /// </summary>
+        public static bool IsOffline(DateTime lastUpdate, DateTime utcNow)
+        {
+            return lastUpdate != default && lastUpdate <= utcNow.AddMinutes(-HealthCutoffMinutes);
+        }
+
+        /// <summary>
+        /// A beacon railroad is "truly" offline — the state an OfflineNote is tied to — only
+        /// when neither a health check nor telemetry has been received recently. This is
+        /// deliberately broader than the Online flag (which is health-check-only, driving the
+        /// gray/blue-ring map visuals): telemetry receipt alone must also be able to clear a
+        /// note, per the offline-note feature's requirements.
+        /// </summary>
+        public static bool IsTrulyOffline(DateTime lastHealthUpdate, DateTime? lastTelemetryUpdate, DateTime utcNow)
+        {
+            var healthOffline = IsOffline(lastHealthUpdate, utcNow);
+            var telemetryOffline = !lastTelemetryUpdate.HasValue || IsOffline(lastTelemetryUpdate.Value, utcNow);
+            return healthOffline && telemetryOffline;
         }
     }
 }

--- a/Web/Web.Server/Services/BeaconRailroadService.cs
+++ b/Web/Web.Server/Services/BeaconRailroadService.cs
@@ -53,5 +53,10 @@ namespace Web.Server.Services
         {
             return await _repository.DeleteAsync(beaconId, railroadId);
         }
+
+        public async Task<DateTime?> GetLatestTelemetryTimestampAsync(int beaconId, int subdivisionId)
+        {
+            return await _repository.GetLatestTelemetryTimestampAsync(beaconId, subdivisionId);
+        }
     }
 }

--- a/Web/Web.Server/Services/IBeaconRailroadService.cs
+++ b/Web/Web.Server/Services/IBeaconRailroadService.cs
@@ -10,5 +10,6 @@ namespace Web.Server.Services
         Task<BeaconRailroad> UpdateAsync(BeaconRailroad beaconRailroad);
         Task<ICollection<BeaconRailroad>> UpdateAsync(ICollection<BeaconRailroad> beaconRailroads);
         Task<bool> DeleteAsync(int beaconId, int railroadId);
+        Task<DateTime?> GetLatestTelemetryTimestampAsync(int beaconId, int subdivisionId);
     }
 }

--- a/Web/Web.ServerTests/Controllers/BeaconRailroadsControllerTests.cs
+++ b/Web/Web.ServerTests/Controllers/BeaconRailroadsControllerTests.cs
@@ -1,0 +1,328 @@
+using MapsterMapper;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Web.Server.Controllers.v1;
+using Web.Server.DTOs;
+using Web.Server.Entities;
+using Web.Server.Enums;
+using Web.Server.Providers;
+using Web.Server.Services;
+
+namespace Web.ServerTests.Controllers;
+
+[TestClass]
+public class BeaconRailroadsControllerTests
+{
+    private static readonly DateTime Now = new(2026, 7, 26, 12, 0, 0, DateTimeKind.Utc);
+
+    [TestMethod]
+    public async Task Create_NonAdmin_IsForbidden()
+    {
+        var (controller, serviceMock, _, _, _) = CreateController(userId: 1, roleName: "Custodian");
+
+        var result = await controller.Create(new CreateBeaconRailroadDTO { BeaconID = 1, SubdivisionID = 1 });
+
+        var objectResult = result as ObjectResult;
+        Assert.IsNotNull(objectResult);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, objectResult.StatusCode);
+        serviceMock.Verify(s => s.AddAsync(It.IsAny<BeaconRailroad>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task Delete_NonAdmin_IsForbidden()
+    {
+        var (controller, serviceMock, _, _, _) = CreateController(userId: 1, roleName: "Custodian");
+
+        var result = await controller.Delete(1, 1);
+
+        var statusResult = result as IStatusCodeActionResult;
+        Assert.IsNotNull(statusResult);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, statusResult.StatusCode);
+        serviceMock.Verify(s => s.DeleteAsync(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task GetAll_ComputesOnline_FromLastUpdate()
+    {
+        var offlineEntity = SeedBeaconRailroad(custodianId: null, lastUpdate: Now.AddMinutes(-20));
+        var onlineEntity = SeedBeaconRailroad(custodianId: null, lastUpdate: Now.AddMinutes(-5));
+        onlineEntity.BeaconID = 2;
+
+        var (controller, serviceMock, _, mapperMock, _) = CreateController(userId: 70, roleName: "Admin");
+
+        serviceMock.Setup(s => s.GetAllAsync()).ReturnsAsync([offlineEntity, onlineEntity]);
+        mapperMock
+            .Setup(m => m.Map<IEnumerable<BeaconRailroadDTO>>(It.IsAny<IEnumerable<BeaconRailroad>>()))
+            .Returns((IEnumerable<BeaconRailroad> entities) => entities.Select(e => new BeaconRailroadDTO
+            {
+                BeaconID = e.BeaconID,
+                SubdivisionID = e.SubdivisionID,
+                LastUpdate = e.LastUpdate
+            }));
+
+        var result = await controller.GetAll();
+
+        var okResult = result as OkObjectResult;
+        Assert.IsNotNull(okResult);
+        var envelope = okResult.Value as MessageEnvelope<IEnumerable<BeaconRailroadDTO>>;
+        Assert.IsNotNull(envelope);
+        var dtos = envelope.Data!.ToList();
+
+        Assert.IsFalse(dtos.First(d => d.BeaconID == 1).Online, "20-minute-old LastUpdate should be offline.");
+        Assert.IsTrue(dtos.First(d => d.BeaconID == 2).Online, "5-minute-old LastUpdate should be online.");
+    }
+
+    [TestMethod]
+    public async Task GetById_ComputesOnline_FromLastUpdate()
+    {
+        var offlineEntity = SeedBeaconRailroad(custodianId: null, lastUpdate: Now.AddMinutes(-20));
+
+        var (controller, serviceMock, _, mapperMock, _) = CreateController(userId: 70, roleName: "Admin", existing: offlineEntity);
+
+        mapperMock
+            .Setup(m => m.Map<BeaconRailroadDTO>(offlineEntity))
+            .Returns(new BeaconRailroadDTO
+            {
+                BeaconID = offlineEntity.BeaconID,
+                SubdivisionID = offlineEntity.SubdivisionID,
+                LastUpdate = offlineEntity.LastUpdate
+            });
+
+        var result = await controller.GetById(offlineEntity.BeaconID, offlineEntity.SubdivisionID);
+
+        var okResult = result.Result as OkObjectResult;
+        Assert.IsNotNull(okResult);
+        var envelope = okResult.Value as MessageEnvelope<BeaconRailroadDTO>;
+        Assert.IsNotNull(envelope);
+        Assert.IsFalse(envelope.Data!.Online, "20-minute-old LastUpdate should be offline.");
+    }
+
+    [TestMethod]
+    public async Task Update_Admin_CanSetOfflineNote_WhenOffline()
+    {
+        var existing = SeedBeaconRailroad(custodianId: null, lastUpdate: Now.AddMinutes(-20)); // offline
+        var dto = ToUpdateDto(existing);
+        dto.OfflineNote = "Storm damage to relay box";
+
+        var mapped = new BeaconRailroad
+        {
+            BeaconID = existing.BeaconID,
+            SubdivisionID = existing.SubdivisionID,
+            Direction = dto.Direction,
+            Latitude = dto.Latitude,
+            Longitude = dto.Longitude,
+            Milepost = dto.Milepost,
+            MultipleTracks = dto.MultipleTracks,
+            TelemetryStaleHoursOverride = dto.TelemetryStaleHoursOverride,
+            OfflineNote = dto.OfflineNote
+        };
+
+        var (controller, serviceMock, _, mapperMock, _) = CreateController(userId: 70, roleName: "Admin", existing: existing);
+
+        mapperMock.Setup(m => m.Map<BeaconRailroad>(dto)).Returns(mapped);
+
+        var result = await controller.Update(existing.BeaconID, existing.SubdivisionID, dto);
+
+        Assert.IsInstanceOfType(result, typeof(NoContentResult));
+        serviceMock.Verify(s => s.UpdateAsync(It.Is<BeaconRailroad>(br => br.OfflineNote == "Storm damage to relay box")), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task Update_SettingOfflineNote_WhileOnline_IsRejected()
+    {
+        var existing = SeedBeaconRailroad(custodianId: null, lastUpdate: Now); // online
+        var dto = ToUpdateDto(existing);
+        dto.OfflineNote = "Should not be allowed";
+
+        var (controller, serviceMock, _, _, _) = CreateController(userId: 70, roleName: "Admin", existing: existing);
+
+        var result = await controller.Update(existing.BeaconID, existing.SubdivisionID, dto);
+
+        var badRequest = result as BadRequestObjectResult;
+        Assert.IsNotNull(badRequest);
+        var envelope = badRequest.Value as MessageEnvelope<BeaconRailroadDTO>;
+        Assert.IsNotNull(envelope);
+        Assert.IsTrue(envelope.Errors.Any(e => e.Contains("currently online", StringComparison.OrdinalIgnoreCase)));
+        serviceMock.Verify(s => s.UpdateAsync(It.IsAny<BeaconRailroad>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task Update_SettingOfflineNote_WhenTelemetryRecentlyReceived_IsRejected_EvenIfHealthCheckOffline()
+    {
+        // Per the offline-note feature's own definition, "offline" means neither health check
+        // NOR telemetry is being received. A beacon that's health-offline but has recent
+        // telemetry is not truly offline, so setting a note on it must be rejected the same as
+        // for a fully online beacon.
+        var existing = SeedBeaconRailroad(custodianId: null, lastUpdate: Now.AddMinutes(-20)); // health-offline
+        var dto = ToUpdateDto(existing);
+        dto.OfflineNote = "Should not be allowed";
+
+        var (controller, serviceMock, _, _, _) = CreateController(userId: 70, roleName: "Admin", existing: existing);
+        serviceMock
+            .Setup(s => s.GetLatestTelemetryTimestampAsync(existing.BeaconID, existing.SubdivisionID))
+            .ReturnsAsync(Now.AddMinutes(-2)); // telemetry just received
+
+        var result = await controller.Update(existing.BeaconID, existing.SubdivisionID, dto);
+
+        var badRequest = result as BadRequestObjectResult;
+        Assert.IsNotNull(badRequest);
+        var envelope = badRequest.Value as MessageEnvelope<BeaconRailroadDTO>;
+        Assert.IsNotNull(envelope);
+        Assert.IsTrue(envelope.Errors.Any(e => e.Contains("currently online", StringComparison.OrdinalIgnoreCase)));
+        serviceMock.Verify(s => s.UpdateAsync(It.IsAny<BeaconRailroad>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task Update_AssignedCustodian_CanUpdateOnlyOfflineNote_WhenOffline()
+    {
+        var existing = SeedBeaconRailroad(custodianId: 50, lastUpdate: Now.AddMinutes(-30)); // offline
+        var dto = ToUpdateDto(existing);
+        dto.OfflineNote = "Track washed out";
+
+        var (controller, serviceMock, _, mapperMock, _) = CreateController(userId: 50, roleName: "Custodian", existing: existing);
+
+        var result = await controller.Update(existing.BeaconID, existing.SubdivisionID, dto);
+
+        Assert.IsInstanceOfType(result, typeof(NoContentResult));
+        serviceMock.Verify(s => s.UpdateAsync(It.Is<BeaconRailroad>(br =>
+            br.OfflineNote == "Track washed out" &&
+            br.Latitude == existing.Latitude &&
+            br.Longitude == existing.Longitude &&
+            br.Milepost == existing.Milepost &&
+            br.MultipleTracks == existing.MultipleTracks &&
+            br.Direction == existing.Direction)), Times.Once);
+        mapperMock.Verify(m => m.Map<BeaconRailroad>(It.IsAny<UpdateBeaconRailroadDTO>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task Update_AssignedCustodian_CannotChangeOtherFields()
+    {
+        var existing = SeedBeaconRailroad(custodianId: 51, lastUpdate: Now.AddMinutes(-30)); // offline
+        var dto = ToUpdateDto(existing);
+        dto.Milepost = existing.Milepost + 5;
+
+        var (controller, serviceMock, _, _, _) = CreateController(userId: 51, roleName: "Custodian", existing: existing);
+
+        var result = await controller.Update(existing.BeaconID, existing.SubdivisionID, dto);
+
+        var objectResult = result as ObjectResult;
+        Assert.IsNotNull(objectResult);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, objectResult.StatusCode);
+
+        var envelope = objectResult.Value as MessageEnvelope<BeaconRailroadDTO>;
+        Assert.IsNotNull(envelope);
+        Assert.IsTrue(envelope.Errors.Any(e => e.Contains("OfflineNote", StringComparison.OrdinalIgnoreCase)));
+        serviceMock.Verify(s => s.UpdateAsync(It.IsAny<BeaconRailroad>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task Update_UnassignedCustodian_IsForbidden()
+    {
+        var existing = SeedBeaconRailroad(custodianId: 999, lastUpdate: Now.AddMinutes(-30)); // offline
+        var dto = ToUpdateDto(existing);
+        dto.OfflineNote = "Not my subdivision";
+
+        var (controller, serviceMock, _, _, _) = CreateController(userId: 52, roleName: "Custodian", existing: existing);
+
+        var result = await controller.Update(existing.BeaconID, existing.SubdivisionID, dto);
+
+        var objectResult = result as ObjectResult;
+        Assert.IsNotNull(objectResult);
+        Assert.AreEqual(StatusCodes.Status403Forbidden, objectResult.StatusCode);
+        serviceMock.Verify(s => s.UpdateAsync(It.IsAny<BeaconRailroad>()), Times.Never);
+    }
+
+    private static BeaconRailroad SeedBeaconRailroad(int? custodianId, DateTime lastUpdate)
+    {
+        return new BeaconRailroad
+        {
+            BeaconID = 1,
+            SubdivisionID = 1,
+            Direction = Direction.NorthSouth,
+            Latitude = 43.3,
+            Longitude = -88.2,
+            Milepost = 101.5,
+            MultipleTracks = true,
+            TelemetryStaleHoursOverride = null,
+            LastUpdate = lastUpdate,
+            Subdivision = new Subdivision
+            {
+                ID = 1,
+                Name = "Test",
+                RailroadID = 1,
+                CustodianId = custodianId
+            }
+        };
+    }
+
+    private static UpdateBeaconRailroadDTO ToUpdateDto(BeaconRailroad existing)
+    {
+        return new UpdateBeaconRailroadDTO
+        {
+            BeaconID = existing.BeaconID,
+            SubdivisionID = existing.SubdivisionID,
+            Direction = existing.Direction,
+            Latitude = existing.Latitude,
+            Longitude = existing.Longitude,
+            Milepost = existing.Milepost,
+            MultipleTracks = existing.MultipleTracks,
+            TelemetryStaleHoursOverride = existing.TelemetryStaleHoursOverride,
+            OfflineNote = existing.OfflineNote
+        };
+    }
+
+    private static (BeaconRailroadsController Controller, Mock<IBeaconRailroadService> ServiceMock, Mock<IUserService> UserServiceMock, Mock<IMapper> MapperMock, Mock<ITimeProvider> TimeProviderMock) CreateController(
+        int userId, string roleName, BeaconRailroad? existing = null)
+    {
+        var serviceMock = new Mock<IBeaconRailroadService>();
+        var userServiceMock = new Mock<IUserService>();
+        var timeProviderMock = new Mock<ITimeProvider>();
+        var loggerMock = new Mock<ILogger<BeaconRailroadsController>>();
+        var mapperMock = new Mock<IMapper>();
+
+        timeProviderMock.Setup(tp => tp.UtcNow).Returns(Now);
+
+        userServiceMock
+            .Setup(s => s.GetUserByIdAsync(userId))
+            .ReturnsAsync(new User
+            {
+                ID = userId,
+                IsActive = true,
+                UserRoles =
+                [
+                    new UserRole { Role = new Role { RoleName = roleName }, User = null!, AssignedAt = Now }
+                ]
+            });
+
+        if (existing != null)
+        {
+            serviceMock
+                .Setup(s => s.GetByIdAsync(existing.BeaconID, existing.SubdivisionID))
+                .ReturnsAsync(existing);
+        }
+
+        serviceMock
+            .Setup(s => s.UpdateAsync(It.IsAny<BeaconRailroad>()))
+            .ReturnsAsync((BeaconRailroad br) => br);
+
+        var controller = new BeaconRailroadsController(
+            serviceMock.Object,
+            userServiceMock.Object,
+            timeProviderMock.Object,
+            loggerMock.Object,
+            mapperMock.Object);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Items["UserId"] = userId;
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+
+        return (controller, serviceMock, userServiceMock, mapperMock, timeProviderMock);
+    }
+}

--- a/Web/Web.ServerTests/Repositories/BeaconRailroadRepositoryTests.cs
+++ b/Web/Web.ServerTests/Repositories/BeaconRailroadRepositoryTests.cs
@@ -39,6 +39,91 @@ namespace Web.ServerTests.Repositories
         }
 
         [TestMethod]
+        public async Task UpdateAsync_DoesNotBumpLastUpdate()
+        {
+            // LastUpdate is the sole signal BeaconRailroadHealthService uses to determine
+            // online/offline. If UpdateAsync bumped it on ordinary edits, saving something as
+            // unrelated as an OfflineNote would spuriously mark an offline beacon "online" again.
+            var seededLastUpdate = new DateTime(2026, 7, 17, 11, 0, 0, DateTimeKind.Utc); // 1 hour before the update call
+            var updateCallTime = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc);
+            var (context, timeProviderMock) = BuildContext(updateCallTime);
+
+            await SeedBeaconRailroadAsync(context, seededLastUpdate, telemetryStaleHoursOverride: null);
+
+            var repository = new BeaconRailroadRepository(context, timeProviderMock.Object);
+            var update = new BeaconRailroad
+            {
+                BeaconID = 1,
+                SubdivisionID = 1,
+                Direction = Direction.NorthSouth,
+                Latitude = 43.3,
+                Longitude = -88.2,
+                Milepost = 101.5,
+                MultipleTracks = true,
+                OfflineNote = "Downed power line near milepost 101"
+            };
+
+            await repository.UpdateAsync(update);
+
+            var persisted = await context.BeaconRailroads.FirstAsync(br => br.BeaconID == 1 && br.SubdivisionID == 1);
+            Assert.AreEqual(seededLastUpdate, persisted.LastUpdate, "LastUpdate must be untouched by ordinary metadata/note edits.");
+        }
+
+        [TestMethod]
+        public async Task UpdateAsync_PersistsOfflineNote_WhenSet()
+        {
+            var now = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc);
+            var (context, timeProviderMock) = BuildContext(now);
+
+            await SeedBeaconRailroadAsync(context, now, telemetryStaleHoursOverride: null);
+
+            var repository = new BeaconRailroadRepository(context, timeProviderMock.Object);
+            var update = new BeaconRailroad
+            {
+                BeaconID = 1,
+                SubdivisionID = 1,
+                Direction = Direction.NorthSouth,
+                Latitude = 43.3,
+                Longitude = -88.2,
+                Milepost = 101.5,
+                MultipleTracks = true,
+                OfflineNote = "Downed power line near milepost 101"
+            };
+
+            await repository.UpdateAsync(update);
+
+            var persisted = await context.BeaconRailroads.FirstAsync(br => br.BeaconID == 1 && br.SubdivisionID == 1);
+            Assert.AreEqual("Downed power line near milepost 101", persisted.OfflineNote);
+        }
+
+        [TestMethod]
+        public async Task UpdateAsync_ClearsOfflineNote_WhenNull()
+        {
+            var now = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc);
+            var (context, timeProviderMock) = BuildContext(now);
+
+            await SeedBeaconRailroadAsync(context, now, telemetryStaleHoursOverride: null, offlineNote: "Existing note");
+
+            var repository = new BeaconRailroadRepository(context, timeProviderMock.Object);
+            var update = new BeaconRailroad
+            {
+                BeaconID = 1,
+                SubdivisionID = 1,
+                Direction = Direction.NorthSouth,
+                Latitude = 43.3,
+                Longitude = -88.2,
+                Milepost = 101.5,
+                MultipleTracks = true,
+                OfflineNote = null
+            };
+
+            await repository.UpdateAsync(update);
+
+            var persisted = await context.BeaconRailroads.FirstAsync(br => br.BeaconID == 1 && br.SubdivisionID == 1);
+            Assert.IsNull(persisted.OfflineNote);
+        }
+
+        [TestMethod]
         public async Task UpdateAsync_ClearsTelemetryStaleHoursOverride_WhenNull()
         {
             var now = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc);
@@ -65,6 +150,61 @@ namespace Web.ServerTests.Repositories
             Assert.IsNull(persisted.TelemetryStaleHoursOverride);
         }
 
+        [TestMethod]
+        public async Task GetLatestTelemetryTimestampAsync_ReturnsMostRecent_ForMatchingBeaconAndSubdivision()
+        {
+            var now = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc);
+            var (context, timeProviderMock) = BuildContext(now);
+            await SeedBeaconRailroadAsync(context, now, telemetryStaleHoursOverride: null);
+
+            var older = now.AddHours(-2);
+            var newest = now.AddMinutes(-5);
+            context.MapPinHistories.Add(new MapPinHistory
+            {
+                BeaconID = 1,
+                SubdivisionId = 1,
+                AddressesJson = "[]",
+                CreatedAt = older,
+                LastUpdate = older
+            });
+            context.MapPinHistories.Add(new MapPinHistory
+            {
+                BeaconID = 1,
+                SubdivisionId = 1,
+                AddressesJson = "[]",
+                CreatedAt = newest,
+                LastUpdate = newest
+            });
+            // Different subdivision — must not be picked up for BeaconID=1/SubdivisionID=1.
+            context.MapPinHistories.Add(new MapPinHistory
+            {
+                BeaconID = 1,
+                SubdivisionId = 2,
+                AddressesJson = "[]",
+                CreatedAt = now,
+                LastUpdate = now
+            });
+            await context.SaveChangesAsync();
+
+            var repository = new BeaconRailroadRepository(context, timeProviderMock.Object);
+            var result = await repository.GetLatestTelemetryTimestampAsync(1, 1);
+
+            Assert.AreEqual(newest, result);
+        }
+
+        [TestMethod]
+        public async Task GetLatestTelemetryTimestampAsync_ReturnsNull_WhenNoTelemetryRecorded()
+        {
+            var now = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc);
+            var (context, timeProviderMock) = BuildContext(now);
+            await SeedBeaconRailroadAsync(context, now, telemetryStaleHoursOverride: null);
+
+            var repository = new BeaconRailroadRepository(context, timeProviderMock.Object);
+            var result = await repository.GetLatestTelemetryTimestampAsync(1, 1);
+
+            Assert.IsNull(result);
+        }
+
         private static (TelemetryDbContext Context, Mock<ITimeProvider> TimeProviderMock) BuildContext(DateTime now)
         {
             var options = new DbContextOptionsBuilder<TelemetryDbContext>()
@@ -78,7 +218,7 @@ namespace Web.ServerTests.Repositories
             return (context, timeProviderMock);
         }
 
-        private static async Task SeedBeaconRailroadAsync(TelemetryDbContext context, DateTime now, int? telemetryStaleHoursOverride)
+        private static async Task SeedBeaconRailroadAsync(TelemetryDbContext context, DateTime now, int? telemetryStaleHoursOverride, string? offlineNote = null)
         {
             var owner = new User
             {
@@ -133,6 +273,7 @@ namespace Web.ServerTests.Repositories
                 Milepost = 100.0,
                 MultipleTracks = false,
                 TelemetryStaleHoursOverride = telemetryStaleHoursOverride,
+                OfflineNote = offlineNote,
                 CreatedAt = now,
                 LastUpdate = now
             };

--- a/Web/Web.ServerTests/Services/BeaconRailroadHealthServiceTests.cs
+++ b/Web/Web.ServerTests/Services/BeaconRailroadHealthServiceTests.cs
@@ -326,6 +326,100 @@ namespace Web.ServerTests.Services
             Assert.IsTrue(dto.TelemetryStale, "TelemetryStale should be true when no telemetry has ever been received");
         }
 
+        // ── OfflineNote clearing ────────────────────────────────────────────────
+
+        [TestMethod]
+        public async Task OfflineNote_IsCleared_WhenBeaconComesBackOnline()
+        {
+            var dbName = nameof(OfflineNote_IsCleared_WhenBeaconComesBackOnline);
+            using var dbContext = CreateInMemoryDbContext(dbName);
+
+            SeedHealthyBeacon(dbContext, beaconId: 1, subdivisionId: 1, telemetryStaleHoursOverride: null,
+                lastHealthUpdate: DateTime.UtcNow.AddMinutes(-5), // online
+                lastTelemetryUpdate: DateTime.UtcNow.AddHours(-1));
+
+            var beaconRailroad = await dbContext.BeaconRailroads.FirstAsync(br => br.BeaconID == 1 && br.SubdivisionID == 1);
+            beaconRailroad.OfflineNote = "Storm damage";
+            await dbContext.SaveChangesAsync();
+
+            _serviceProviderMock.Setup(sp => sp.GetService(typeof(TelemetryDbContext))).Returns(dbContext);
+
+            var config = BuildConfig(defaultHours: 6);
+            var sentDTOs = CaptureBeaconUpdate();
+
+            RunOneIteration(config, dbContext);
+
+            var dto = sentDTOs.First(d => d.BeaconID == 1);
+            Assert.IsTrue(dto.Online, "Beacon should be online");
+            Assert.IsNull(dto.OfflineNote, "OfflineNote should be cleared in the broadcast DTO once the beacon is back online");
+
+            var persisted = await dbContext.BeaconRailroads.FirstAsync(br => br.BeaconID == 1 && br.SubdivisionID == 1);
+            Assert.IsNull(persisted.OfflineNote, "OfflineNote should be cleared and persisted once the beacon is back online");
+        }
+
+        [TestMethod]
+        public async Task OfflineNote_IsPreserved_WhileBeaconRemainsOffline()
+        {
+            var dbName = nameof(OfflineNote_IsPreserved_WhileBeaconRemainsOffline);
+            using var dbContext = CreateInMemoryDbContext(dbName);
+
+            SeedHealthyBeacon(dbContext, beaconId: 1, subdivisionId: 1, telemetryStaleHoursOverride: null,
+                lastHealthUpdate: DateTime.UtcNow.AddMinutes(-20), // offline
+                lastTelemetryUpdate: DateTime.UtcNow.AddHours(-1));
+
+            var beaconRailroad = await dbContext.BeaconRailroads.FirstAsync(br => br.BeaconID == 1 && br.SubdivisionID == 1);
+            beaconRailroad.OfflineNote = "Storm damage";
+            await dbContext.SaveChangesAsync();
+
+            _serviceProviderMock.Setup(sp => sp.GetService(typeof(TelemetryDbContext))).Returns(dbContext);
+
+            var config = BuildConfig(defaultHours: 6);
+            var sentDTOs = CaptureBeaconUpdate();
+
+            RunOneIteration(config, dbContext);
+
+            var dto = sentDTOs.First(d => d.BeaconID == 1);
+            Assert.IsFalse(dto.Online, "Beacon should still be offline");
+            Assert.AreEqual("Storm damage", dto.OfflineNote, "OfflineNote should be preserved while the beacon remains offline");
+
+            var persisted = await dbContext.BeaconRailroads.FirstAsync(br => br.BeaconID == 1 && br.SubdivisionID == 1);
+            Assert.AreEqual("Storm damage", persisted.OfflineNote);
+        }
+
+        [TestMethod]
+        public async Task OfflineNote_IsCleared_WhenTelemetryReceived_EvenIfHealthCheckStillOffline()
+        {
+            // Reproduces the reported bug: telemetry arrives for an offline beacon (no health
+            // check yet), but the note never cleared because clearing was gated solely on the
+            // health-check-based Online flag. Per the feature's own definition, "offline" means
+            // neither health check NOR telemetry is being received — so recent telemetry alone
+            // must also clear the note.
+            var dbName = nameof(OfflineNote_IsCleared_WhenTelemetryReceived_EvenIfHealthCheckStillOffline);
+            using var dbContext = CreateInMemoryDbContext(dbName);
+
+            SeedHealthyBeacon(dbContext, beaconId: 1, subdivisionId: 1, telemetryStaleHoursOverride: null,
+                lastHealthUpdate: DateTime.UtcNow.AddMinutes(-20), // still health-offline
+                lastTelemetryUpdate: DateTime.UtcNow.AddMinutes(-2)); // telemetry just received
+
+            var beaconRailroad = await dbContext.BeaconRailroads.FirstAsync(br => br.BeaconID == 1 && br.SubdivisionID == 1);
+            beaconRailroad.OfflineNote = "Storm damage";
+            await dbContext.SaveChangesAsync();
+
+            _serviceProviderMock.Setup(sp => sp.GetService(typeof(TelemetryDbContext))).Returns(dbContext);
+
+            var config = BuildConfig(defaultHours: 6);
+            var sentDTOs = CaptureBeaconUpdate();
+
+            RunOneIteration(config, dbContext);
+
+            var dto = sentDTOs.First(d => d.BeaconID == 1);
+            Assert.IsFalse(dto.Online, "Online (gray/blue map visual) stays health-check-only and should remain offline");
+            Assert.IsNull(dto.OfflineNote, "OfflineNote should be cleared once telemetry is received, even without a health check");
+
+            var persisted = await dbContext.BeaconRailroads.FirstAsync(br => br.BeaconID == 1 && br.SubdivisionID == 1);
+            Assert.IsNull(persisted.OfflineNote);
+        }
+
         // ── TelemetryStaleHoursOverride passthrough in DTO ────────────────────
 
         [TestMethod]

--- a/Web/web.client/src/api/beaconRailroads.ts
+++ b/Web/web.client/src/api/beaconRailroads.ts
@@ -8,6 +8,14 @@ const SESSION_KEY = 'rjtt_auth_session';
 const COOKIE_NAME = 'rjtt_auth';
 
 function getAuthToken(): string | null {
+  const localData = localStorage.getItem(SESSION_KEY);
+  if (localData) {
+    try {
+      const session = JSON.parse(localData) as AuthSession;
+      return session.token;
+    } catch { }
+  }
+
   const cookieData = getCookie(COOKIE_NAME);
   if (cookieData) {
     try {
@@ -15,7 +23,7 @@ function getAuthToken(): string | null {
       return session.token;
     } catch { }
   }
-  
+
   const sessionData = sessionStorage.getItem(SESSION_KEY);
   if (sessionData) {
     try {
@@ -23,7 +31,7 @@ function getAuthToken(): string | null {
       return session.token;
     } catch { }
   }
-  
+
   return null;
 }
 

--- a/Web/web.client/src/api/beaconsApi.test.ts
+++ b/Web/web.client/src/api/beaconsApi.test.ts
@@ -72,6 +72,42 @@ describe('fetchBeacons (soft-refresh / visibility-change path)', () => {
     expect(result[0].telemetryStale).toBe(false);
   });
 
+  it('reproduces the reported bug: preserves a SignalR-confirmed offlineNote instead of losing it to a stale cached snapshot', async () => {
+    // Simulates returning to the tab after several minutes: the IndexedDB cache
+    // snapshot predates the note (or was written before it existed), while
+    // localStorage holds the freshest truth from the last SignalR tick.
+    const cachedBeacons = [
+      { beaconID: '1', beaconName: 'Rugby Jct', online: false, offlineNote: null }
+    ];
+    mockedOpenRailwaysDB.mockResolvedValue(makeFakeDb(cachedBeacons) as any);
+    localStorage.setItem('beaconStatusMap', JSON.stringify({ '1': false }));
+    localStorage.setItem('beaconOfflineNoteMap', JSON.stringify({ '1': 'Storm damage' }));
+
+    const setBeacons = vi.fn();
+    const setBeaconsLoaded = vi.fn();
+
+    await fetchBeacons(setBeacons, setBeaconsLoaded);
+
+    const result = setBeacons.mock.calls[0][0];
+    expect(result[0].offlineNote).toBe('Storm damage');
+  });
+
+  it('leaves offlineNote as-is when nothing has been recorded for that beacon yet', async () => {
+    const cachedBeacons = [
+      { beaconID: '99', beaconName: 'NewBeacon', online: false, offlineNote: 'Existing' }
+    ];
+    mockedOpenRailwaysDB.mockResolvedValue(makeFakeDb(cachedBeacons) as any);
+    // No beaconOfflineNoteMap entry for beacon 99.
+
+    const setBeacons = vi.fn();
+    const setBeaconsLoaded = vi.fn();
+
+    await fetchBeacons(setBeacons, setBeaconsLoaded);
+
+    const result = setBeacons.mock.calls[0][0];
+    expect(result[0].offlineNote).toBe('Existing');
+  });
+
   it('still applies the existing online grace-period overlay alongside the new telemetryStale preservation', async () => {
     const cachedBeacons = [
       { beaconID: '7', beaconName: 'Flicker', online: false, telemetryStale: true }

--- a/Web/web.client/src/api/beaconsApi.ts
+++ b/Web/web.client/src/api/beaconsApi.ts
@@ -25,6 +25,11 @@ export const fetchBeacons = async (setBeacons: any, setBeaconsLoaded: any) => {
     const raw = localStorage.getItem('beaconTelemetryStaleMap');
     if (raw) telemetryStaleMap = JSON.parse(raw);
   } catch { /* ignore */ }
+  let offlineNoteMap: Record<string, string | null> = {};
+  try {
+    const raw = localStorage.getItem('beaconOfflineNoteMap');
+    if (raw) offlineNoteMap = JSON.parse(raw);
+  } catch { /* ignore */ }
   const graceUntil = Number(localStorage.getItem('focusGraceUntil') || '0');
   const now = Date.now();
 
@@ -32,6 +37,7 @@ export const fetchBeacons = async (setBeacons: any, setBeaconsLoaded: any) => {
     const withStatus = (cached as any[]).map(b => {
       const prevOnline = statusMap[b.beaconID];
       const prevStale = telemetryStaleMap[b.beaconID];
+      const prevOfflineNote = offlineNoteMap[b.beaconID];
       let result = b;
       if (prevOnline === true && b.online === false && now < graceUntil) {
         result = { ...result, online: true };
@@ -40,6 +46,9 @@ export const fetchBeacons = async (setBeacons: any, setBeaconsLoaded: any) => {
       }
       if (prevStale !== undefined) {
         result = { ...result, telemetryStale: prevStale };
+      }
+      if (prevOfflineNote !== undefined) {
+        result = { ...result, offlineNote: prevOfflineNote };
       }
       return result;
     });
@@ -62,6 +71,7 @@ export const fetchBeacons = async (setBeacons: any, setBeaconsLoaded: any) => {
     const withStatus = (beacons as any[]).map(b => {
       const prevOnline = statusMap[b.beaconID];
       const prevStale = telemetryStaleMap[b.beaconID];
+      const prevOfflineNote = offlineNoteMap[b.beaconID];
       let result = b;
       if (prevOnline === true && b.online === false && now < graceUntil) {
         result = { ...result, online: true };
@@ -70,6 +80,9 @@ export const fetchBeacons = async (setBeacons: any, setBeaconsLoaded: any) => {
       }
       if (prevStale !== undefined) {
         result = { ...result, telemetryStale: prevStale };
+      }
+      if (prevOfflineNote !== undefined) {
+        result = { ...result, offlineNote: prevOfflineNote };
       }
       return result;
     });

--- a/Web/web.client/src/components/BeaconMarker.test.ts
+++ b/Web/web.client/src/components/BeaconMarker.test.ts
@@ -62,6 +62,28 @@ describe('getBeaconVisualState', () => {
         });
     });
 
+    describe('offline beacon with a note', () => {
+        it('reports hasOfflineNote when offline and a note is present', () => {
+            const state = getBeaconVisualState(makeBeacon({ online: false, offlineNote: 'Storm damage' }));
+            expect(state.hasOfflineNote).toBe(true);
+        });
+
+        it('does not report hasOfflineNote when offline but no note is present', () => {
+            const state = getBeaconVisualState(makeBeacon({ online: false, offlineNote: null }));
+            expect(state.hasOfflineNote).toBe(false);
+        });
+
+        it('does not report hasOfflineNote when online, even if a note is somehow present', () => {
+            const state = getBeaconVisualState(makeBeacon({ online: true, offlineNote: 'Stale note' }));
+            expect(state.hasOfflineNote).toBe(false);
+        });
+
+        it('reports title indicating a note is available when offline with a note', () => {
+            const state = getBeaconVisualState(makeBeacon({ online: false, offlineNote: 'Storm damage' }));
+            expect(state.title).toBe('offline - click for note');
+        });
+    });
+
     describe('telemetry-stale beacon (blue ring)', () => {
         it('is telemetry stale when online and telemetryStale is true', () => {
             const state = getBeaconVisualState(makeBeacon({ online: true, telemetryStale: true }));

--- a/Web/web.client/src/components/BeaconMarker.tsx
+++ b/Web/web.client/src/components/BeaconMarker.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useRef, useEffect, useMemo } from 'react';
 import { Marker } from 'react-leaflet';
 import L from 'leaflet';
 import { Beacon } from '../types/Beacon';
 import { metersToPixels } from '../utils/geo';
 import { getBeaconDotSizePx } from '../utils/markerSizing';
+import { BEACON_ONLINE_COLOR, BEACON_OFFLINE_COLOR } from '../constants/beaconColors';
 
 // Adjustable real-world diameter for the outline (in meters)
 const OUTLINE_DIAMETER_METERS = 7080;
@@ -17,28 +18,42 @@ interface BeaconMarkerProps {
     mapTheme?: 'dark' | 'light';
 }
 
+function escapeHtml(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
 export interface BeaconVisualState {
     isOffline: boolean;
     isTelemetryStale: boolean;
     color: string;
     dotCenterColor: string;
     title: string;
+    hasOfflineNote: boolean;
 }
 
 export function getBeaconVisualState(beacon: Beacon, mapTheme: 'dark' | 'light' = 'dark'): BeaconVisualState {
     const isOffline = beacon.online === false;
     const isTelemetryStale = beacon.online !== false && beacon.telemetryStale === true;
-    const color = isOffline ? '#888888' : '#005aa9';
+    const hasOfflineNote = isOffline && !!beacon.offlineNote;
+    const color = isOffline ? BEACON_OFFLINE_COLOR : BEACON_ONLINE_COLOR;
     const dotCenterColor = isTelemetryStale
         ? (mapTheme === 'dark' ? '#1a1a2e' : '#ffffff')
         : color;
-    const title = isOffline ? 'offline' : isTelemetryStale ? 'telemetry stale' : 'online';
-    return { isOffline, isTelemetryStale, color, dotCenterColor, title };
+    const title = isOffline
+        ? (hasOfflineNote ? 'offline - click for note' : 'offline')
+        : isTelemetryStale ? 'telemetry stale' : 'online';
+    return { isOffline, isTelemetryStale, color, dotCenterColor, title, hasOfflineNote };
 }
 
 const BeaconMarker: React.FC<BeaconMarkerProps> = ({ pin: beaconPin, zoom, idx, mapTheme = 'dark' }) => {
     const beaconName = beaconPin.beaconName;
-    const { isOffline, isTelemetryStale, dotCenterColor, title } = getBeaconVisualState(beaconPin, mapTheme);
+    const { isOffline, isTelemetryStale, dotCenterColor, title, hasOfflineNote } = getBeaconVisualState(beaconPin, mapTheme);
+    const markerRef = useRef<L.Marker>(null);
 
     const beaconDotSizePx = getBeaconDotSizePx(zoom);
 
@@ -104,36 +119,152 @@ const BeaconMarker: React.FC<BeaconMarkerProps> = ({ pin: beaconPin, zoom, idx, 
         \" ></div>`
         : '';
 
+    // Small badge marking an offline beacon that has a note to view (click target)
+    const noteBadgeSizePx = Math.max(10, Math.round(beaconDotSizePx * 0.55));
+    const noteBadge = hasOfflineNote
+        ? `<div class=\"beacon-note-badge\" style=\"
+            position:absolute;
+            top:${beaconDotOffsetPx - noteBadgeSizePx * 0.3}px;
+            left:${beaconDotOffsetPx + beaconDotSizePx - noteBadgeSizePx * 0.7}px;
+            width:${noteBadgeSizePx}px;
+            height:${noteBadgeSizePx}px;
+            border-radius:50%;
+            background:#f5a623;
+            color:#1a1a2e;
+            font-size:${Math.max(8, Math.round(noteBadgeSizePx * 0.7))}px;
+            font-weight:700;
+            font-family: Georgia, 'Times New Roman', serif;
+            display:flex;
+            align-items:center;
+            justify-content:center;
+            z-index:3;
+            pointer-events:auto;
+            cursor:pointer;
+            box-shadow:0 0 0 1px rgba(0,0,0,0.4);
+            line-height:1;
+        \">i</div>`
+        : '';
+
+    // Memoized so Leaflet doesn't tear down and recreate the marker's DOM element on every
+    // unrelated re-render (e.g. SignalR ticks for other beacons) — a fresh element would
+    // silently detach the click listener bound to the (now stale) previous element below.
+    const markerIcon = useMemo(() => L.divIcon({
+        className: 'beacon-marker-z',
+        html: `
+            <div class=\"beacon-container\" style=\"position: relative; width: ${outlineSize}px; height: ${outlineSize}px; pointer-events: none;\">
+                ${dottedOutline}
+                ${telemetryStaleRing}
+                <div class=\"beacon-dot\" title=\"${beaconName} ${title}\" style=\"
+                    width:${beaconDotSizePx}px;
+                    height:${beaconDotSizePx}px;
+                    background:${dotCenterColor};
+                    border-radius:50%;
+                    position:absolute;
+                    top:${beaconDotOffsetPx}px;
+                    left:${beaconDotOffsetPx}px;
+                    z-index:2;
+                    pointer-events: auto;
+                    cursor: pointer;
+                    ${isTelemetryStale ? `border: 2px solid #005aa9;` : ''}
+                \" ></div>
+                ${noteBadge}
+                ${pingDiv}
+            </div>
+        `,
+        iconSize: [outlineSize, outlineSize],
+        iconAnchor: [outlineSize / 2, outlineSize / 2],
+        popupAnchor: [0, -(beaconDotSizePx / 2 + 4)],
+    }), [
+        outlineSize,
+        beaconDotSizePx,
+        beaconDotOffsetPx,
+        dotCenterColor,
+        isTelemetryStale,
+        beaconName,
+        title,
+        dottedOutline,
+        telemetryStaleRing,
+        noteBadge,
+        pingDiv,
+    ]);
+
+    // Inject the same dark-mode popup CSS used by TelemetryMarker/PassengerTelemetryMarker so
+    // the offline-note popup matches the rest of the map's Leaflet popups (idempotent: guarded
+    // by element id, so it's a no-op if another marker already injected it).
+    useEffect(() => {
+        const styleId = 'leaflet-popup-darkmode-style';
+        if (!document.getElementById(styleId)) {
+            const style = document.createElement('style');
+            style.id = styleId;
+            style.innerHTML = `
+                body[data-theme='dark'] .leaflet-popup-content-wrapper,
+                .dark .leaflet-popup-content-wrapper {
+                    background: #181a1b !important;
+                    color: #f3f3f3 !important;
+                    border: 1px solid #333 !important;
+                    box-shadow: 0 0 8px rgba(0, 123, 255, 0.6);
+                }
+                body[data-theme='dark'] .leaflet-popup-content,
+                .dark .leaflet-popup-content {
+                    color: #f3f3f3 !important;
+                }
+                body[data-theme='dark'] .leaflet-popup-tip,
+                .dark .leaflet-popup-tip {
+                    background: #181a1b !important;
+                    border: 1px solid #333 !important;
+                    box-shadow: 0 0 8px rgba(0, 123, 255, 0.6);
+                }
+            `;
+            document.head.appendChild(style);
+        }
+    }, []);
+
+    // Bind a native Leaflet popup showing the offline note, toggled on click — matches the
+    // popup pattern used for Amtrak/telemetry markers elsewhere on the map. Re-bound whenever
+    // markerIcon changes since react-leaflet swaps the marker's underlying DOM element (via
+    // Leaflet's setIcon) any time the icon reference changes.
+    useEffect(() => {
+        const marker = markerRef.current;
+        if (!marker) return;
+
+        if (!hasOfflineNote || !beaconPin.offlineNote) {
+            marker.unbindPopup();
+            return;
+        }
+
+        const popupContent = `
+            <div>
+                <strong>${escapeHtml(beaconName)}</strong><br/>
+                <span style="color:#f5a623;font-weight:600;">Offline</span><br/>
+                ${escapeHtml(beaconPin.offlineNote)}
+            </div>
+        `;
+        marker.bindPopup(popupContent);
+
+        let popupOpen = false;
+        const handleClick = () => {
+            if (popupOpen) {
+                marker.closePopup();
+            } else {
+                marker.openPopup();
+            }
+            popupOpen = !popupOpen;
+        };
+        marker.on('click', handleClick);
+
+        return () => {
+            marker.off('click', handleClick);
+            marker.unbindPopup();
+        };
+    }, [markerIcon, hasOfflineNote, beaconPin.offlineNote, beaconName]);
+
     return (
         <Marker
+            ref={markerRef}
             key={`beacon-${beaconPin.beaconID ?? idx}-${beaconPin.latitude}-${beaconPin.longitude}`}
             position={[beaconPin.latitude, beaconPin.longitude]}
             pane="beaconPane"
-            icon={L.divIcon({
-                className: 'beacon-marker-z',
-                html: `
-                    <div class=\"beacon-container\" style=\"position: relative; width: ${outlineSize}px; height: ${outlineSize}px; pointer-events: none;\">
-                        ${dottedOutline}
-                        ${telemetryStaleRing}
-                        <div class=\"beacon-dot\" title=\"${beaconName} ${title}\" style=\"
-                            width:${beaconDotSizePx}px;
-                            height:${beaconDotSizePx}px;
-                            background:${dotCenterColor};
-                            border-radius:50%;
-                            position:absolute;
-                            top:${beaconDotOffsetPx}px;
-                            left:${beaconDotOffsetPx}px;
-                            z-index:2;
-                            pointer-events: auto;
-                            cursor: pointer;
-                            ${isTelemetryStale ? `border: 2px solid #005aa9;` : ''}
-                        \" ></div>
-                        ${pingDiv}
-                    </div>
-                `,
-                iconSize: [outlineSize, outlineSize],
-                iconAnchor: [outlineSize / 2, outlineSize / 2],
-            })}
+            icon={markerIcon}
         />
     );
 };

--- a/Web/web.client/src/components/BeaconMarkers.tsx
+++ b/Web/web.client/src/components/BeaconMarkers.tsx
@@ -21,7 +21,7 @@ const BeaconMarkers: React.FC<BeaconMarkersProps> = ({
     pins: beaconPins, 
     zoom, 
     mapTheme, 
-    beaconLastUpdateMap, 
+    beaconLastUpdateMap,
     onBeaconClick,
     trackedPins = [],
     mapPins = [],

--- a/Web/web.client/src/constants/beaconColors.ts
+++ b/Web/web.client/src/constants/beaconColors.ts
@@ -1,0 +1,4 @@
+// Shared color language for beacon online/offline status, used by both the
+// map markers (BeaconMarker) and the admin beacon railroad status column.
+export const BEACON_ONLINE_COLOR = '#005aa9';
+export const BEACON_OFFLINE_COLOR = '#888888';

--- a/Web/web.client/src/hooks/useBeacons.ts
+++ b/Web/web.client/src/hooks/useBeacons.ts
@@ -16,6 +16,11 @@ export function useBeacons() {
     const raw = localStorage.getItem('beaconTelemetryStaleMap');
     if (raw) initialStaleMap = JSON.parse(raw);
   } catch { /* ignore malformed storage */ }
+  let initialOfflineNoteMap: Record<string, string | null> = {};
+  try {
+    const raw = localStorage.getItem('beaconOfflineNoteMap');
+    if (raw) initialOfflineNoteMap = JSON.parse(raw);
+  } catch { /* ignore malformed storage */ }
 
   useEffect(() => {
     const fetchBeacons = async () => {
@@ -70,6 +75,7 @@ export function useBeacons() {
         const withStatus = (cached as Beacon[]).map(b => {
           const stored = initialStatusMap[b.beaconID];
           const storedStale = initialStaleMap[b.beaconID];
+          const storedOfflineNote = initialOfflineNoteMap[b.beaconID];
           let result = b;
           if (stored === true && b.online === false && now < graceUntil) {
             result = { ...result, online: true };
@@ -78,6 +84,9 @@ export function useBeacons() {
           }
           if (storedStale !== undefined) {
             result = { ...result, telemetryStale: storedStale };
+          }
+          if (storedOfflineNote !== undefined) {
+            result = { ...result, offlineNote: storedOfflineNote };
           }
           return result;
         });
@@ -119,6 +128,7 @@ export function useBeacons() {
         const withStatus = (beacons as Beacon[]).map(b => {
           const stored = initialStatusMap[b.beaconID];
           const storedStale = initialStaleMap[b.beaconID];
+          const storedOfflineNote = initialOfflineNoteMap[b.beaconID];
           let result = b;
           if (stored === true && b.online === false && now < graceUntil) {
             result = { ...result, online: true };
@@ -127,6 +137,9 @@ export function useBeacons() {
           }
           if (storedStale !== undefined) {
             result = { ...result, telemetryStale: storedStale };
+          }
+          if (storedOfflineNote !== undefined) {
+            result = { ...result, offlineNote: storedOfflineNote };
           }
           return result;
         });
@@ -144,15 +157,18 @@ export function useBeacons() {
     if (!beacons.length) return;
     const statusMap: Record<string, boolean> = {};
     const staleMap: Record<string, boolean> = {};
+    const offlineNoteMap: Record<string, string | null> = {};
     beacons.forEach(b => {
       if (b && b.beaconID) {
         statusMap[b.beaconID] = !!b.online;
         staleMap[b.beaconID] = !!b.telemetryStale;
+        offlineNoteMap[b.beaconID] = b.offlineNote ?? null;
       }
     });
     try {
       localStorage.setItem('beaconStatusMap', JSON.stringify(statusMap));
       localStorage.setItem('beaconTelemetryStaleMap', JSON.stringify(staleMap));
+      localStorage.setItem('beaconOfflineNoteMap', JSON.stringify(offlineNoteMap));
     } catch { /* ignore quota */ }
   }, [beacons]);
 

--- a/Web/web.client/src/hooks/useBeacons.ts
+++ b/Web/web.client/src/hooks/useBeacons.ts
@@ -23,7 +23,7 @@ export function useBeacons() {
       const DB_VERSION = 2;
       // Cache schema version - increment when beacon data structure changes
       // This ensures stale cached data without new fields (like railroad/subdivision names) is refreshed
-      const BEACON_CACHE_VERSION = 3; // v3: telemetryStale fix — invalidate caches written while the backend always returned false
+      const BEACON_CACHE_VERSION = 4; // v4: offlineNote added — invalidate caches written before the field existed
       const CACHE_VERSION_KEY = 'beacons_version';
       
       const db = await openDB('railways-db', DB_VERSION, {
@@ -108,7 +108,8 @@ export function useBeacons() {
           longitude: b.longitude,
           milepost: b.milepost,
           online: b.online,
-          telemetryStale: b.telemetryStale
+          telemetryStale: b.telemetryStale,
+          offlineNote: b.offlineNote
         }));
         
         // Store beacons and cache version together

--- a/Web/web.client/src/index.css
+++ b/Web/web.client/src/index.css
@@ -193,6 +193,15 @@ body:has(.admin-layout) .app-footer {
 /* ---------- Marker Z-Index ---------- */
 .beacon-marker-z {
   z-index: 400;
+  /* This marker's outer div is oversized (to fit the "ping" animation ring) and
+     mostly empty space. Leaflet's own .leaflet-interactive rule sets
+     pointer-events: auto at equal specificity and loads after this stylesheet,
+     so !important is needed to actually win. Without this, a neighboring
+     beacon's oversized container can overlap and intercept clicks meant for
+     this marker's own dot/badge underneath (e.g. two beacon railroads sharing
+     one junction). The dot/badge elements set pointer-events: auto inline,
+     which beats this via specificity and opts them back in. */
+  pointer-events: none !important;
 }
 .telemetry-marker-z {
   z-index: 500;
@@ -371,4 +380,12 @@ body:has(.admin-layout) .app-footer {
 .beacon-container,
 .beacon-container * {
   cursor: grab !important;
+}
+/* .beacon-dot / .beacon-note-badge are actually clickable (offline-note badge),
+   so they should show the pointer cursor, not the pannable-map grab cursor above.
+   Higher specificity (two classes) than ".beacon-container *" so it wins regardless
+   of source order. */
+.beacon-container .beacon-dot,
+.beacon-container .beacon-note-badge {
+  cursor: pointer !important;
 }

--- a/Web/web.client/src/types/AdminBeaconRailroad.ts
+++ b/Web/web.client/src/types/AdminBeaconRailroad.ts
@@ -12,6 +12,7 @@ export interface AdminBeaconRailroad {
   online: boolean;
   direction: Direction;
   telemetryStaleHoursOverride?: number | null;
+  offlineNote?: string | null;
 }
 
 export type Direction = 'All' | 'NorthSouth' | 'EastWest' | 'NortheastSouthwest' | 'NorthwestSoutheast';
@@ -26,6 +27,7 @@ export interface CreateBeaconRailroad {
   online: boolean;
   direction: Direction;
   telemetryStaleHoursOverride?: number | null;
+  offlineNote?: string | null;
 }
 
 export interface UpdateBeaconRailroad {
@@ -38,4 +40,5 @@ export interface UpdateBeaconRailroad {
   online: boolean;
   direction: Direction;
   telemetryStaleHoursOverride?: number | null;
+  offlineNote?: string | null;
 }

--- a/Web/web.client/src/types/Beacon.ts
+++ b/Web/web.client/src/types/Beacon.ts
@@ -10,4 +10,5 @@ export type Beacon = {
     milepost: number;
     online: boolean; // primitive boolean for reliable equality checks & persistence
     telemetryStale?: boolean; // true when health endpoint is pinging but telemetry is stale past threshold
+    offlineNote?: string | null; // note explaining why this beacon railroad is offline; cleared automatically once back online
 };

--- a/Web/web.client/src/views/AdminBeaconRailroads.test.ts
+++ b/Web/web.client/src/views/AdminBeaconRailroads.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { validateTelemetryStaleHoursOverride } from './AdminBeaconRailroads';
+import { validateTelemetryStaleHoursOverride, canEditOfflineNote } from './AdminBeaconRailroads';
 
 describe('validateTelemetryStaleHoursOverride', () => {
   it('returns null for null (no override)', () => {
@@ -34,5 +34,29 @@ describe('validateTelemetryStaleHoursOverride', () => {
   it('returns an error for a negative float', () => {
     const error = validateTelemetryStaleHoursOverride(-0.5);
     expect(error).toBe('Telemetry stale hours override must be a whole integer greater than zero');
+  });
+});
+
+describe('canEditOfflineNote', () => {
+  it('allows admins regardless of subdivision custodian', () => {
+    expect(canEditOfflineNote(true, false, 999, 1)).toBe(true);
+    expect(canEditOfflineNote(true, false, null, 1)).toBe(true);
+  });
+
+  it('allows a custodian assigned to the subdivision', () => {
+    expect(canEditOfflineNote(false, true, 50, 50)).toBe(true);
+  });
+
+  it('denies a custodian not assigned to the subdivision', () => {
+    expect(canEditOfflineNote(false, true, 999, 50)).toBe(false);
+  });
+
+  it('denies a custodian when the subdivision has no assigned custodian', () => {
+    expect(canEditOfflineNote(false, true, null, 50)).toBe(false);
+    expect(canEditOfflineNote(false, true, undefined, 50)).toBe(false);
+  });
+
+  it('denies a user who is neither admin nor custodian', () => {
+    expect(canEditOfflineNote(false, false, 50, 50)).toBe(false);
   });
 });

--- a/Web/web.client/src/views/AdminBeaconRailroads.tsx
+++ b/Web/web.client/src/views/AdminBeaconRailroads.tsx
@@ -13,6 +13,9 @@ import IconButton from '@mui/material/IconButton';
 import ClearIcon from '@mui/icons-material/Clear';
 import AdminPageHeader from '../components/admin/AdminPageHeader';
 import { adminClearButtonSx } from '../components/admin/adminSx';
+import { useAuth } from '../hooks/useAuth';
+import { parseSessionRoles } from '../utils/roles';
+import { BEACON_ONLINE_COLOR, BEACON_OFFLINE_COLOR } from '../constants/beaconColors';
 
 type SortField = 'beaconName' | 'subdivisionName' | 'railroadName' | 'milepost';
 type SortDirection = 'asc' | 'desc' | null;
@@ -29,6 +32,20 @@ export function validateTelemetryStaleHoursOverride(value: number | null | undef
     return 'Telemetry stale hours override must be a whole integer greater than zero';
   }
   return null;
+}
+
+/**
+ * Determines whether the current user may edit the Offline Note field for a beacon railroad.
+ * Admins can always edit; Custodians only for beacon railroads on their own assigned subdivision.
+ */
+export function canEditOfflineNote(
+  isAdmin: boolean,
+  isCustodian: boolean,
+  subdivisionCustodianId: number | null | undefined,
+  currentUserId: number | null | undefined
+): boolean {
+  if (isAdmin) return true;
+  return isCustodian && subdivisionCustodianId != null && subdivisionCustodianId === currentUserId;
 }
 
 const AdminBeaconRailroads = () => {
@@ -48,13 +65,23 @@ const AdminBeaconRailroads = () => {
     multipleTracks: false,
     online: true,
     direction: 'All',
-    telemetryStaleHoursOverride: null
+    telemetryStaleHoursOverride: null,
+    offlineNote: null
   });
   const [searchTerm, setSearchTerm] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(10);
   const [sortField, setSortField] = useState<SortField>('beaconName');
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
+
+  const { session } = useAuth();
+  const { isAdmin, isCustodian } = parseSessionRoles(session?.roles);
+  const currentUserId = session?.userId ?? null;
+  const editingSubdivision = editingBeaconRailroad
+    ? subdivisions.find(s => s.id === editingBeaconRailroad.subdivisionID)
+    : undefined;
+  const canEditNote = canEditOfflineNote(isAdmin, isCustodian, editingSubdivision?.custodianId, currentUserId);
+  const canEditStructuralFields = isAdmin || !editingBeaconRailroad;
 
   useEffect(() => {
     loadData();
@@ -159,7 +186,8 @@ const AdminBeaconRailroads = () => {
       multipleTracks: false,
       online: true,
       direction: 'All',
-      telemetryStaleHoursOverride: null
+      telemetryStaleHoursOverride: null,
+      offlineNote: null
     });
     setError(undefined);
     setShowModal(true);
@@ -176,7 +204,8 @@ const AdminBeaconRailroads = () => {
       multipleTracks: beaconRailroad.multipleTracks,
       online: beaconRailroad.online,
       direction: beaconRailroad.direction,
-      telemetryStaleHoursOverride: beaconRailroad.telemetryStaleHoursOverride ?? null
+      telemetryStaleHoursOverride: beaconRailroad.telemetryStaleHoursOverride ?? null,
+      offlineNote: beaconRailroad.offlineNote ?? null
     });
     setError(undefined);
     setShowModal(true);
@@ -293,7 +322,7 @@ const AdminBeaconRailroads = () => {
           </Tooltip>
         </div>
         <div className="right-controls">
-          <button className="btn-primary" onClick={handleAdd}>Add Beacon Railroad</button>
+          {isAdmin && <button className="btn-primary" onClick={handleAdd}>Add Beacon Railroad</button>}
         </div>
       </div>
 
@@ -316,6 +345,7 @@ const AdminBeaconRailroads = () => {
               <th>Milepost</th>
               <th>Direction</th>
               <th>Multi-Track</th>
+              <th>Status</th>
               <th>Actions</th>
             </tr>
           </thead>
@@ -329,9 +359,23 @@ const AdminBeaconRailroads = () => {
                 <td>{br.milepost.toFixed(1)}</td>
                 <td>{formatDirection(br.direction)}</td>
                 <td>{br.multipleTracks ? 'Yes' : 'No'}</td>
+                <td>
+                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
+                    <span style={{
+                      display: 'inline-block',
+                      width: '10px',
+                      height: '10px',
+                      borderRadius: '50%',
+                      background: br.online ? BEACON_ONLINE_COLOR : BEACON_OFFLINE_COLOR
+                    }} />
+                    {br.online ? 'Online' : 'Offline'}
+                  </span>
+                </td>
                 <td className="actions-cell">
                   <button className="btn-edit" onClick={() => handleEdit(br)}>Edit</button>
-                  <button className="btn-delete" onClick={() => handleDelete(br.beaconID, br.subdivisionID)}>Delete</button>
+                  {isAdmin && (
+                    <button className="btn-delete" onClick={() => handleDelete(br.beaconID, br.subdivisionID)}>Delete</button>
+                  )}
                 </td>
               </tr>
             ))}
@@ -427,6 +471,7 @@ const AdminBeaconRailroads = () => {
                     value={formData.latitude}
                     onChange={(e) => setFormData({ ...formData, latitude: parseFloat(e.target.value) })}
                     placeholder="43.294944"
+                    disabled={!canEditStructuralFields}
                   />
                 </div>
 
@@ -439,6 +484,7 @@ const AdminBeaconRailroads = () => {
                     value={formData.longitude}
                     onChange={(e) => setFormData({ ...formData, longitude: parseFloat(e.target.value) })}
                     placeholder="-88.253118"
+                    disabled={!canEditStructuralFields}
                   />
                 </div>
               </div>
@@ -453,6 +499,7 @@ const AdminBeaconRailroads = () => {
                     value={formData.milepost}
                     onChange={(e) => setFormData({ ...formData, milepost: parseFloat(e.target.value) })}
                     placeholder="123.4"
+                    disabled={!canEditStructuralFields}
                   />
                 </div>
 
@@ -462,6 +509,7 @@ const AdminBeaconRailroads = () => {
                     id="direction"
                     value={formData.direction}
                     onChange={(e) => setFormData({ ...formData, direction: e.target.value as Direction })}
+                    disabled={!canEditStructuralFields}
                   >
                     {DIRECTION_OPTIONS.map(dir => (
                       <option key={dir} value={dir}>
@@ -478,6 +526,7 @@ const AdminBeaconRailroads = () => {
                     type="checkbox"
                     checked={formData.multipleTracks}
                     onChange={(e) => setFormData({ ...formData, multipleTracks: e.target.checked })}
+                    disabled={!canEditStructuralFields}
                   />
                   Multiple Tracks
                 </label>
@@ -499,8 +548,43 @@ const AdminBeaconRailroads = () => {
                     });
                   }}
                   placeholder="Leave blank to use default (6 hours)"
+                  disabled={!canEditStructuralFields}
                 />
               </div>
+
+              {editingBeaconRailroad && (
+                <>
+                  <div className="form-group">
+                    <label>Status</label>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                      <span style={{
+                        display: 'inline-block',
+                        width: '10px',
+                        height: '10px',
+                        borderRadius: '50%',
+                        background: editingBeaconRailroad.online ? BEACON_ONLINE_COLOR : BEACON_OFFLINE_COLOR
+                      }} />
+                      {editingBeaconRailroad.online ? 'Online' : 'Offline'}
+                    </div>
+                  </div>
+
+                  <div className="form-group">
+                    <label htmlFor="offlineNote">Offline Note</label>
+                    <div className="form-help">
+                      {editingBeaconRailroad.online
+                        ? 'Only available while this beacon railroad is offline.'
+                        : 'Explain why this beacon railroad is offline. Cleared automatically once it comes back online.'}
+                    </div>
+                    <textarea
+                      id="offlineNote"
+                      value={formData.offlineNote || ''}
+                      onChange={(e) => setFormData({ ...formData, offlineNote: e.target.value })}
+                      rows={4}
+                      disabled={editingBeaconRailroad.online || !canEditNote}
+                    />
+                  </div>
+                </>
+              )}
 
               <div className="form-actions">
                 <button type="button" className="btn-secondary" onClick={() => setShowModal(false)}>

--- a/Web/web.client/src/views/RailMap.tsx
+++ b/Web/web.client/src/views/RailMap.tsx
@@ -286,7 +286,8 @@ const RailMap: React.FC = () => {
                         longitude: b.longitude,
                         milepost: b.milepost,
                         online: b.online,
-                        telemetryStale: b.telemetryStale
+                        telemetryStale: b.telemetryStale,
+                        offlineNote: b.offlineNote
                     };
                     // Filter out beacons with invalid IDs (0 or null/undefined)
                     if (mappedBeacon.beaconID && Number(mappedBeacon.beaconID) !== 0 && mappedBeacon.railroadID && Number(mappedBeacon.railroadID) !== 0) {


### PR DESCRIPTION
Closes #69

## Summary

Admins and the subdivision's assigned Custodian can attach a note explaining why a beacon railroad is offline. Anyone can view it by clicking the gray dot's badge on the map, which opens a Leaflet popup with the note text (matching the existing Amtrak/telemetry popup style). The note is automatically cleared once the beacon comes back online, via either a health check or telemetry receipt.

**Backend**
- `BeaconRailroad.OfflineNote` (nullable string) + EF migration.
- `BeaconRailroadsController` now enforces Admin-or-assigned-Custodian authorization on Create/Update/Delete (previously had none at all). Custodians are restricted to editing only `OfflineNote`, and setting a note is rejected (400) unless the beacon railroad is genuinely offline.
- `BeaconRailroadHealthService` clears the note automatically once a beacon recovers — via health check *or* telemetry, per the feature's own definition of "offline" (neither signal being received). Broadcasts the change over the existing SignalR `BeaconUpdate` event.

**Frontend**
- Admin page (`AdminBeaconRailroads.tsx`): new Status column, an Offline Note field (enabled only while offline, scoped to Admins/assigned Custodians), non-note fields locked down for Custodians.
- Map: gray dots with a note show a small badge; clicking it opens a native Leaflet popup (anchored, with a close button) showing the note. Dots without a note do nothing on click.

## Bug fixes found and fixed during testing

- `BeaconRailroadsController` had no authorization at all before this PR.
- `BeaconRailroadRepository.UpdateAsync` was bumping `LastUpdate` on every edit — the same field the health service uses for online/offline — so saving any field (including the new note) spuriously revived offline beacons as "online".
- `GetAll`/`GetById` never actually computed the `Online` flag, always defaulting to `false`; the admin page's new status column exposed this.
- `beaconRailroads.ts`'s auth token lookup never checked `localStorage`, where the session is actually stored, so authenticated requests from this admin page silently carried no token.
- `BeaconMarker`'s Leaflet icon wasn't memoized, so react-leaflet recreated its DOM element on unrelated re-renders, detaching the click listener.
- The marker's oversized invisible "ping" container had no `pointer-events` restriction, letting a neighboring beacon's marker (e.g. a junction with two beacon railroads sharing a location) intercept clicks meant for this one.
- A blanket `cursor: grab` rule was overriding the dot/badge's own `cursor: pointer`.
- Note clearing/setting validation only considered the health-check-based `Online` flag, not telemetry — so telemetry receipt alone couldn't clear a note, contradicting the feature's own definition of offline.

## Test plan

- [x] Backend: `dotnet test` — 171 passed, 1 pre-existing skip (Web.ServerTests)
- [x] Frontend: `npm test` — 42 passed (web.client)
- [x] Frontend type-check: `tsc --noEmit` clean
- [x] Manually verified end-to-end in a running instance (login, add note as Admin, click map badge, popup opens with correct text, note clears after telemetry/health-check recovery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
