### PR TITLE
Add inline Local toggle to beacon history flyout rows

### DIFF
--- a/Web/Web.Server/Services/LocalTrainEvaluator.cs
+++ b/Web/Web.Server/Services/LocalTrainEvaluator.cs
@@ -1,0 +1,31 @@
+using Web.Server.Entities;
+
+namespace Web.Server.Services
+{
+    /// <summary>
+    /// Determines whether an address ID is in a subdivision's local train list.
+    /// Shared by any read path that needs to reflect the subdivision's current
+    /// local-train configuration rather than a stale, previously-computed value.
+    /// </summary>
+    public static class LocalTrainEvaluator
+    {
+        public static bool IsLocalTrain(int addressID, Subdivision? subdivision)
+        {
+            if (subdivision == null || string.IsNullOrWhiteSpace(subdivision.LocalTrainAddressIDs))
+            {
+                return false;
+            }
+
+            var localAddressIDs = subdivision.LocalTrainAddressIDs
+                .Split(new[] { ',', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(id => id.Trim())
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Select(id => int.TryParse(id, out var parsed) ? parsed : (int?)null)
+                .Where(id => id.HasValue)
+                .Select(id => id!.Value)
+                .ToHashSet();
+
+            return localAddressIDs.Contains(addressID);
+        }
+    }
+}

--- a/Web/Web.Server/Services/MapPinHistoryService.cs
+++ b/Web/Web.Server/Services/MapPinHistoryService.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Web.Server.DTOs;
 using Web.Server.Entities;
 using Web.Server.Providers;
 using Web.Server.Repositories;
@@ -45,9 +46,37 @@ namespace Web.Server.Services
             foreach (var history in histories)
             {
                 history.BeaconRailroad = await _beaconRailroadService.GetByIdAsync(history.BeaconID, history.SubdivisionId);
+
+                // IsLocal is persisted at the time telemetry last touched this record, so it goes stale
+                // as soon as a subdivision's local-train list changes. Recompute it from the subdivision's
+                // current settings, the same way MapPinService does for live map pins.
+                history.IsLocal = RecalculateIsLocal(history);
             }
 
             return histories;
+        }
+
+        private static bool RecalculateIsLocal(MapPinHistory history)
+        {
+            if (history.BeaconRailroad?.Subdivision == null || string.IsNullOrWhiteSpace(history.AddressesJson))
+            {
+                return history.IsLocal;
+            }
+
+            try
+            {
+                var addresses = JsonSerializer.Deserialize<List<AddressSnapshotDTO>>(history.AddressesJson);
+                if (addresses == null || addresses.Count == 0)
+                {
+                    return history.IsLocal;
+                }
+
+                return LocalTrainEvaluator.IsLocalTrain(addresses[0].AddressID, history.BeaconRailroad.Subdivision);
+            }
+            catch
+            {
+                return history.IsLocal;
+            }
         }
 
         public async Task<IEnumerable<MapPinHistory>> GetLatestPerBeaconAsync()

--- a/Web/Web.Server/Services/MapPinService.cs
+++ b/Web/Web.Server/Services/MapPinService.cs
@@ -111,7 +111,7 @@ namespace Web.Server.Services
                 if (mapPin.BeaconRailroad?.Subdivision != null && mapPin.Addresses.Any())
                 {
                     var primaryAddressID = mapPin.Addresses.First().AddressID;
-                    mapPin.IsLocal = IsLocalTrain(primaryAddressID, mapPin.BeaconRailroad.Subdivision);
+                    mapPin.IsLocal = LocalTrainEvaluator.IsLocalTrain(primaryAddressID, mapPin.BeaconRailroad.Subdivision);
                 }
             }
 
@@ -129,7 +129,7 @@ namespace Web.Server.Services
                 if (mapPin.BeaconRailroad?.Subdivision != null && mapPin.Addresses.Any())
                 {
                     var primaryAddressID = mapPin.Addresses.First().AddressID;
-                    mapPin.IsLocal = IsLocalTrain(primaryAddressID, mapPin.BeaconRailroad.Subdivision);
+                    mapPin.IsLocal = LocalTrainEvaluator.IsLocalTrain(primaryAddressID, mapPin.BeaconRailroad.Subdivision);
                 }
             }
 
@@ -162,7 +162,7 @@ namespace Web.Server.Services
                     bool isLocal = false;
                     if (primaryAddressID.HasValue && h.BeaconRailroad?.Subdivision != null)
                     {
-                        isLocal = IsLocalTrain(primaryAddressID.Value, h.BeaconRailroad.Subdivision);
+                        isLocal = LocalTrainEvaluator.IsLocalTrain(primaryAddressID.Value, h.BeaconRailroad.Subdivision);
                     }
                     return new MapPin
                     {
@@ -623,7 +623,7 @@ namespace Web.Server.Services
                 mapPin.BeaconID = beaconRailroad.BeaconID;
                 mapPin.SubdivisionId = beaconRailroad.Subdivision.ID;
                 mapPin.CreatedRailroadID = beaconRailroad.Subdivision.RailroadID;
-                mapPin.IsLocal = IsLocalTrain(telemetry.AddressID, beaconRailroad.Subdivision);
+                mapPin.IsLocal = LocalTrainEvaluator.IsLocalTrain(telemetry.AddressID, beaconRailroad.Subdivision);
             }
             else
             {
@@ -635,7 +635,7 @@ namespace Web.Server.Services
                 mapPin.BeaconID = beaconRailroad.BeaconID;
                 mapPin.SubdivisionId = beaconRailroad.Subdivision.ID;
                 mapPin.CreatedRailroadID = beaconRailroad.Subdivision.RailroadID;
-                mapPin.IsLocal = IsLocalTrain(telemetry.AddressID, beaconRailroad.Subdivision);
+                mapPin.IsLocal = LocalTrainEvaluator.IsLocalTrain(telemetry.AddressID, beaconRailroad.Subdivision);
             }
 
             if (telemetry.Moving.HasValue)
@@ -871,7 +871,7 @@ namespace Web.Server.Services
             newMapPin.BeaconID = telemetry.BeaconID;
 
             // Update IsLocal flag based on new subdivision
-            newMapPin.IsLocal = IsLocalTrain(telemetry.AddressID, toBeaconRailroad.Subdivision);
+            newMapPin.IsLocal = LocalTrainEvaluator.IsLocalTrain(telemetry.AddressID, toBeaconRailroad.Subdivision);
             newMapPin.Moving = CalculateMotion(existingMapPinToUpdate, telemetry);
 
             await this.UpdateBeaconTimestamp(toBeaconRailroad);
@@ -927,29 +927,6 @@ namespace Web.Server.Services
             // Update the timestamp for beacon health calculations.
             beaconRailroad.LastUpdate = _timeProvider.UtcNow;
             await _beaconRailroadService.UpdateAsync(beaconRailroad);
-        }
-
-        /// <summary>
-        /// Checks if the given address ID is in the subdivision's local train list.
-        /// </summary>
-        private static bool IsLocalTrain(int addressID, Subdivision subdivision)
-        {
-            if (string.IsNullOrWhiteSpace(subdivision.LocalTrainAddressIDs))
-            {
-                return false;
-            }
-
-            // Parse comma and line-separated list of address IDs
-            var localAddressIDs = subdivision.LocalTrainAddressIDs
-                .Split(new[] { ',', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(id => id.Trim())
-                .Where(id => !string.IsNullOrWhiteSpace(id))
-                .Select(id => int.TryParse(id, out var parsed) ? parsed : (int?)null)
-                .Where(id => id.HasValue)
-                .Select(id => id!.Value)
-                .ToHashSet();
-
-            return localAddressIDs.Contains(addressID);
         }
     }
 }

--- a/Web/Web.ServerTests/Services/LocalTrainEvaluatorTests.cs
+++ b/Web/Web.ServerTests/Services/LocalTrainEvaluatorTests.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics.CodeAnalysis;
+using Web.Server.Entities;
+using Web.Server.Services;
+
+namespace Web.ServerTests.Services
+{
+    [ExcludeFromCodeCoverage]
+    [TestClass]
+    public class LocalTrainEvaluatorTests
+    {
+        private static Subdivision MakeSubdivision(string? localTrainAddressIDs)
+        {
+            return new Subdivision
+            {
+                ID = 1,
+                RailroadID = 1,
+                Railroad = new Railroad { ID = 1, Name = "CN" },
+                Name = "Waukesha",
+                LocalTrainAddressIDs = localTrainAddressIDs,
+            };
+        }
+
+        [TestMethod]
+        public void IsLocalTrain_ReturnsFalse_WhenSubdivisionIsNull()
+        {
+            Assert.IsFalse(LocalTrainEvaluator.IsLocalTrain(1, null));
+        }
+
+        [TestMethod]
+        public void IsLocalTrain_ReturnsFalse_WhenLocalTrainAddressIDsIsNullOrEmpty()
+        {
+            Assert.IsFalse(LocalTrainEvaluator.IsLocalTrain(1, MakeSubdivision(null)));
+            Assert.IsFalse(LocalTrainEvaluator.IsLocalTrain(1, MakeSubdivision("")));
+            Assert.IsFalse(LocalTrainEvaluator.IsLocalTrain(1, MakeSubdivision("   ")));
+        }
+
+        [TestMethod]
+        public void IsLocalTrain_ReturnsTrue_WhenAddressIsInCommaSeparatedList()
+        {
+            Assert.IsTrue(LocalTrainEvaluator.IsLocalTrain(29353, MakeSubdivision("29352,29353,29354")));
+        }
+
+        [TestMethod]
+        public void IsLocalTrain_ReturnsTrue_WhenAddressIsInNewlineSeparatedList()
+        {
+            Assert.IsTrue(LocalTrainEvaluator.IsLocalTrain(29353, MakeSubdivision("29352\n29353\n29354")));
+        }
+
+        [TestMethod]
+        public void IsLocalTrain_ReturnsFalse_WhenAddressIsNotInList()
+        {
+            Assert.IsFalse(LocalTrainEvaluator.IsLocalTrain(99999, MakeSubdivision("29352,29353")));
+        }
+
+        [TestMethod]
+        public void IsLocalTrain_IgnoresNonNumericEntries()
+        {
+            Assert.IsTrue(LocalTrainEvaluator.IsLocalTrain(29353, MakeSubdivision("abc,29353,")));
+        }
+    }
+}

--- a/Web/Web.ServerTests/Services/MapPinHistoryServiceTests.cs
+++ b/Web/Web.ServerTests/Services/MapPinHistoryServiceTests.cs
@@ -1,0 +1,167 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Web.Server.Entities;
+using Web.Server.Providers;
+using Web.Server.Repositories;
+using Web.Server.Services;
+
+namespace Web.ServerTests.Services
+{
+    [ExcludeFromCodeCoverage]
+    [TestClass]
+    public class MapPinHistoryServiceTests
+    {
+        private readonly Mock<IMapPinHistoryRepository> _repositoryMock = new();
+        private readonly Mock<IBeaconRailroadService> _beaconRailroadServiceMock = new();
+        private readonly Mock<ITimeProvider> _timeProviderMock = new();
+        private readonly Mock<IConfiguration> _configurationMock = new();
+
+        private MapPinHistoryService _service;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _timeProviderMock.Setup(tp => tp.UtcNow).Returns(DateTime.UtcNow);
+            _configurationMock.Setup(c => c.GetSection("ApplicationSettings:HistoryTimeThresholdMinutes").Value)
+                .Returns("360");
+            _configurationMock.Setup(c => c.GetSection("ApplicationSettings:StationaryDirectionNullThresholdHours").Value)
+                .Returns("6");
+
+            _service = new MapPinHistoryService(
+                _repositoryMock.Object,
+                _beaconRailroadServiceMock.Object,
+                _timeProviderMock.Object,
+                _configurationMock.Object);
+        }
+
+        private static string AddressesJson(int addressID, string source = "HOT")
+        {
+            return JsonSerializer.Serialize(new[]
+            {
+                new { AddressID = addressID, Source = source, DpuTrainID = (int?)null, CreatedAt = DateTime.UtcNow, LastUpdate = DateTime.UtcNow }
+            });
+        }
+
+        private static Subdivision MakeSubdivision(string? localTrainAddressIDs)
+        {
+            return new Subdivision
+            {
+                ID = 1,
+                RailroadID = 1,
+                Railroad = new Railroad { ID = 1, Name = "CN" },
+                Name = "Waukesha",
+                LocalTrainAddressIDs = localTrainAddressIDs,
+            };
+        }
+
+        private static BeaconRailroad MakeBeaconRailroad(Subdivision subdivision)
+        {
+            return new BeaconRailroad
+            {
+                BeaconID = 1,
+                SubdivisionID = subdivision.ID,
+                Subdivision = subdivision,
+                Latitude = 43.0,
+                Longitude = -88.0,
+                Milepost = 117.2,
+            };
+        }
+
+        [TestMethod]
+        public async Task GetHistoryByBeaconIdAsync_RecomputesIsLocal_TrueWhenAddressNowInSubdivisionLocalList()
+        {
+            // The stored snapshot says false (as it was when the record was last written by telemetry),
+            // but the subdivision's local-train list has since been updated to include this address.
+            var history = new MapPinHistory
+            {
+                ID = 1,
+                BeaconID = 1,
+                SubdivisionId = 1,
+                IsLocal = false,
+                AddressesJson = AddressesJson(29353),
+            };
+
+            var subdivision = MakeSubdivision("29353");
+            _repositoryMock.Setup(r => r.GetByBeaconIdAsync(1, null, null))
+                .ReturnsAsync(new List<MapPinHistory> { history });
+            _beaconRailroadServiceMock.Setup(s => s.GetByIdAsync(1, 1))
+                .ReturnsAsync(MakeBeaconRailroad(subdivision));
+
+            var result = (await _service.GetHistoryByBeaconIdAsync(1)).ToList();
+
+            Assert.AreEqual(1, result.Count);
+            Assert.IsTrue(result[0].IsLocal);
+        }
+
+        [TestMethod]
+        public async Task GetHistoryByBeaconIdAsync_RecomputesIsLocal_FalseWhenAddressRemovedFromSubdivisionLocalList()
+        {
+            // The stored snapshot says true, but the subdivision's local-train list no longer includes it.
+            var history = new MapPinHistory
+            {
+                ID = 2,
+                BeaconID = 1,
+                SubdivisionId = 1,
+                IsLocal = true,
+                AddressesJson = AddressesJson(29353),
+            };
+
+            var subdivision = MakeSubdivision("");
+            _repositoryMock.Setup(r => r.GetByBeaconIdAsync(1, null, null))
+                .ReturnsAsync(new List<MapPinHistory> { history });
+            _beaconRailroadServiceMock.Setup(s => s.GetByIdAsync(1, 1))
+                .ReturnsAsync(MakeBeaconRailroad(subdivision));
+
+            var result = (await _service.GetHistoryByBeaconIdAsync(1)).ToList();
+
+            Assert.IsFalse(result[0].IsLocal);
+        }
+
+        [TestMethod]
+        public async Task GetHistoryByBeaconIdAsync_KeepsStoredIsLocal_WhenBeaconRailroadCannotBeResolved()
+        {
+            var history = new MapPinHistory
+            {
+                ID = 3,
+                BeaconID = 1,
+                SubdivisionId = 1,
+                IsLocal = true,
+                AddressesJson = AddressesJson(29353),
+            };
+
+            _repositoryMock.Setup(r => r.GetByBeaconIdAsync(1, null, null))
+                .ReturnsAsync(new List<MapPinHistory> { history });
+            _beaconRailroadServiceMock.Setup(s => s.GetByIdAsync(1, 1))
+                .ReturnsAsync((BeaconRailroad?)null);
+
+            var result = (await _service.GetHistoryByBeaconIdAsync(1)).ToList();
+
+            Assert.IsTrue(result[0].IsLocal);
+        }
+
+        [TestMethod]
+        public async Task GetHistoryByBeaconIdAsync_KeepsStoredIsLocal_WhenAddressesJsonIsUnparseable()
+        {
+            var history = new MapPinHistory
+            {
+                ID = 4,
+                BeaconID = 1,
+                SubdivisionId = 1,
+                IsLocal = true,
+                AddressesJson = "not valid json",
+            };
+
+            var subdivision = MakeSubdivision("");
+            _repositoryMock.Setup(r => r.GetByBeaconIdAsync(1, null, null))
+                .ReturnsAsync(new List<MapPinHistory> { history });
+            _beaconRailroadServiceMock.Setup(s => s.GetByIdAsync(1, 1))
+                .ReturnsAsync(MakeBeaconRailroad(subdivision));
+
+            var result = (await _service.GetHistoryByBeaconIdAsync(1)).ToList();
+
+            Assert.IsTrue(result[0].IsLocal);
+        }
+    }
+}

--- a/Web/web.client/src/components/BeaconHistoryModal.test.ts
+++ b/Web/web.client/src/components/BeaconHistoryModal.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { formatDirectionAbbreviation, getPrimaryLocalToggleAddress } from './BeaconHistoryModal';
+import type { AddressSnapshot } from '../types/MapPinHistory';
+
+describe('formatDirectionAbbreviation', () => {
+    it.each([
+        ['N', 'N'],
+        ['S', 'S'],
+        ['E', 'E'],
+        ['W', 'W'],
+        ['NE', 'NE'],
+        ['NW', 'NW'],
+        ['SE', 'SE'],
+        ['SW', 'SW'],
+    ])('returns the compass abbreviation for %s', (input, expected) => {
+        expect(formatDirectionAbbreviation(input)).toBe(expected);
+    });
+
+    it('is case-insensitive', () => {
+        expect(formatDirectionAbbreviation('nw')).toBe('NW');
+    });
+
+    it('returns "?" when direction is missing', () => {
+        expect(formatDirectionAbbreviation(undefined)).toBe('?');
+        expect(formatDirectionAbbreviation(null)).toBe('?');
+        expect(formatDirectionAbbreviation('')).toBe('?');
+    });
+
+    it('passes through unrecognized values as-is', () => {
+        expect(formatDirectionAbbreviation('XYZ')).toBe('XYZ');
+    });
+});
+
+function makeAddress(overrides: Partial<AddressSnapshot> = {}): AddressSnapshot {
+    return {
+        addressID: 1,
+        source: 'HOT',
+        createdAt: '2026-01-01T00:00:00Z',
+        lastUpdate: '2026-01-01T00:00:00Z',
+        ...overrides,
+    };
+}
+
+describe('getPrimaryLocalToggleAddress', () => {
+    it('returns the first address when multiple are present', () => {
+        const addresses = [makeAddress({ addressID: 5 }), makeAddress({ addressID: 9 })];
+        expect(getPrimaryLocalToggleAddress(addresses)?.addressID).toBe(5);
+    });
+
+    it('returns the single address when only one is present', () => {
+        const addresses = [makeAddress({ addressID: 42 })];
+        expect(getPrimaryLocalToggleAddress(addresses)?.addressID).toBe(42);
+    });
+
+    it('returns undefined when addresses is empty', () => {
+        expect(getPrimaryLocalToggleAddress([])).toBeUndefined();
+    });
+
+    it('returns undefined when addresses is not an array', () => {
+        expect(getPrimaryLocalToggleAddress(undefined)).toBeUndefined();
+    });
+});

--- a/Web/web.client/src/components/BeaconHistoryModal.tsx
+++ b/Web/web.client/src/components/BeaconHistoryModal.tsx
@@ -1,14 +1,38 @@
 import { format, parseISO } from 'date-fns';
 import { CopyIcon } from './CopyIcon';
 import { useEffect, useState, useRef, useCallback } from 'react';
-import { Typography, Box, IconButton, CircularProgress, Paper } from '@mui/material';
+import { Typography, Box, IconButton, CircularProgress, Paper, Switch } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import { DataGrid, GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
-import { MapPinHistory } from '../types/MapPinHistory';
+import { MapPinHistory, AddressSnapshot } from '../types/MapPinHistory';
 import { MapPin } from '../types/MapPin';
 import { TrackedPin, getTrackedMapPins, refreshTrackedPinsFromApi, addTrackedMapPin, updateTrackedPinSymbol, removeTrackedMapPin, copyTrackedPinShareUrl, buildTrackedPinShareUrl, getTrackedPinSymbol } from '../services/trackedPins';
 import { fetchBeaconHistory } from '../services/mapPinsHistory';
+import { toggleSubdivisionLocalTrainAddress } from '../api/subdivisions';
 import TrackSymbolModal from './TrackSymbolModal';
+
+const DIRECTION_ABBREVIATIONS: { [key: string]: string } = {
+    'N': 'N',
+    'S': 'S',
+    'E': 'E',
+    'W': 'W',
+    'NE': 'NE',
+    'NW': 'NW',
+    'SE': 'SE',
+    'SW': 'SW',
+};
+
+export function formatDirectionAbbreviation(dir?: string | null): string {
+    if (!dir) return '?';
+    return DIRECTION_ABBREVIATIONS[dir.toUpperCase()] || dir;
+}
+
+// History rows don't carry an isActive flag per address (unlike live map pins),
+// so the first address is always used, mirroring the pop-up's find(a => a.isActive) ?? addresses[0] fallback.
+export function getPrimaryLocalToggleAddress(addresses?: AddressSnapshot[]): AddressSnapshot | undefined {
+    return Array.isArray(addresses) ? addresses[0] : undefined;
+}
+
 interface BeaconHistoryModalProps {
     open: boolean;
     onClose: () => void;
@@ -23,9 +47,13 @@ interface BeaconHistoryModalProps {
     trackedPins?: TrackedPin[];
     hourFormat?: string;
     canViewSupportAddresses?: boolean;
+    isAdmin?: boolean;
+    isCustodian?: boolean;
+    currentUserId?: number | null;
 }
 
-export function BeaconHistoryModal({ open, onClose, beaconID, beaconName, subdivisionID, railroad: _railroad, subdivision: _subdivision, theme, lastUpdate, trackedPins: propTrackedPins, hourFormat, canViewSupportAddresses = false }: BeaconHistoryModalProps) {
+export function BeaconHistoryModal({ open, onClose, beaconID, beaconName, subdivisionID, railroad: _railroad, subdivision: _subdivision, theme, lastUpdate, trackedPins: propTrackedPins, hourFormat, canViewSupportAddresses = false, isAdmin = false, isCustodian = false, currentUserId = null }: BeaconHistoryModalProps) {
+    const canManageLocalTrains = isAdmin || isCustodian;
     const [loading, setLoading] = useState(false);
     const [history, setHistory] = useState<MapPinHistory[]>([]);
     const [error, setError] = useState<string | null>(null);
@@ -41,8 +69,11 @@ export function BeaconHistoryModal({ open, onClose, beaconID, beaconName, subdiv
     const [trackedPins, setTrackedPins] = useState(() => propTrackedPins || getTrackedMapPins());
     const [refreshKey, setRefreshKey] = useState(0);
     const [copiedShareCode, setCopiedShareCode] = useState<string | null>(null);
+    const [togglingLocalRowIds, setTogglingLocalRowIds] = useState<Set<number>>(new Set());
+    const [localToggleErrors, setLocalToggleErrors] = useState<{ [rowId: number]: string }>({});
     const prevBeaconIDRef = useRef<string | null>(null);
     const copyFeedbackTimeoutRef = useRef<number | null>(null);
+    const localToggleFeedbackTimeoutsRef = useRef<{ [rowId: number]: number }>({});
     const copyIconColor = theme === 'dark' ? '#d5d9df' : '#4b5563';
 
     const fetchHistory = useCallback(async () => {
@@ -68,10 +99,12 @@ export function BeaconHistoryModal({ open, onClose, beaconID, beaconName, subdiv
     }, [propTrackedPins]);
 
     useEffect(() => {
+        const localToggleFeedbackTimeouts = localToggleFeedbackTimeoutsRef.current;
         return () => {
             if (copyFeedbackTimeoutRef.current) {
                 window.clearTimeout(copyFeedbackTimeoutRef.current);
             }
+            Object.values(localToggleFeedbackTimeouts).forEach(id => window.clearTimeout(id));
         };
     }, []);
 
@@ -131,6 +164,63 @@ export function BeaconHistoryModal({ open, onClose, beaconID, beaconName, subdiv
         };
     }, [propTrackedPins]);
 
+    const handleLocalToggle = useCallback(async (row: MapPinHistory, nextIsLocal: boolean) => {
+        const primaryAddress = getPrimaryLocalToggleAddress(row.addresses);
+        if (!primaryAddress) {
+            return;
+        }
+
+        setLocalToggleErrors(prev => {
+            if (!(row.id in prev)) return prev;
+            const next = { ...prev };
+            delete next[row.id];
+            return next;
+        });
+        setTogglingLocalRowIds(prev => new Set(prev).add(row.id));
+        // Optimistically flip the badge so the Train column updates immediately.
+        setHistory(prev => prev.map(h => h.id === row.id ? { ...h, isLocal: nextIsLocal } : h));
+
+        try {
+            const result = await toggleSubdivisionLocalTrainAddress(
+                Number(row.subdivisionID),
+                Number(primaryAddress.addressID),
+                { isAdmin, currentUserId }
+            );
+
+            if (result.errors.length > 0 || !result.data) {
+                // Revert on rejection (e.g. a non-owning Custodian, enforced server-side).
+                setHistory(prev => prev.map(h => h.id === row.id ? { ...h, isLocal: !nextIsLocal } : h));
+                const message = result.errors[0] || 'Failed to update local status.';
+                setLocalToggleErrors(prev => ({ ...prev, [row.id]: message }));
+            } else {
+                setHistory(prev => prev.map(h => h.id === row.id ? { ...h, isLocal: result.data!.isLocal } : h));
+            }
+        } catch (err) {
+            console.error('Failed to toggle local status:', err);
+            setHistory(prev => prev.map(h => h.id === row.id ? { ...h, isLocal: !nextIsLocal } : h));
+            setLocalToggleErrors(prev => ({ ...prev, [row.id]: 'Failed to update local status.' }));
+        } finally {
+            setTogglingLocalRowIds(prev => {
+                const next = new Set(prev);
+                next.delete(row.id);
+                return next;
+            });
+
+            if (localToggleFeedbackTimeoutsRef.current[row.id]) {
+                window.clearTimeout(localToggleFeedbackTimeoutsRef.current[row.id]);
+            }
+            localToggleFeedbackTimeoutsRef.current[row.id] = window.setTimeout(() => {
+                setLocalToggleErrors(prev => {
+                    if (!(row.id in prev)) return prev;
+                    const next = { ...prev };
+                    delete next[row.id];
+                    return next;
+                });
+                delete localToggleFeedbackTimeoutsRef.current[row.id];
+            }, 4000);
+        }
+    }, [isAdmin, currentUserId]);
+
     const columns: GridColDef[] = [
         { field: 'id', headerName: 'ID', width: 70 },
         {
@@ -149,25 +239,11 @@ export function BeaconHistoryModal({ open, onClose, beaconID, beaconName, subdiv
                 }
             }
         },
-        { 
-            field: 'direction', 
-            headerName: 'Direction', 
-            width: 78,
-            valueFormatter: (params) => {
-                const dir = params as string;
-                if (!dir) return '?';
-                const directions: { [key: string]: string } = {
-                    'N': 'North',
-                    'S': 'South',
-                    'E': 'East',
-                    'W': 'West',
-                    'NE': 'Northeast',
-                    'NW': 'Northwest',
-                    'SE': 'Southeast',
-                    'SW': 'Southwest'
-                };
-                return directions[dir.toUpperCase()] || dir;
-            }
+        {
+            field: 'direction',
+            headerName: 'Direction',
+            width: 44,
+            valueFormatter: (params) => formatDirectionAbbreviation(params as string),
         },
         {
             field: 'addresses',
@@ -383,6 +459,61 @@ export function BeaconHistoryModal({ open, onClose, beaconID, beaconName, subdiv
                                 </span>
                             )}
                         </Box>
+                    </Box>
+                );
+            },
+        },
+        {
+            field: 'isLocal',
+            headerName: 'Local',
+            width: 52,
+            sortable: false,
+            filterable: false,
+            renderCell: (params: GridRenderCellParams<MapPinHistory>) => {
+                if (!canManageLocalTrains) {
+                    return null;
+                }
+
+                const row = params.row;
+                const primaryAddress = getPrimaryLocalToggleAddress(row.addresses);
+                const canToggle = !!primaryAddress && Number.isInteger(Number(row.subdivisionID)) && Number(row.subdivisionID) > 0;
+                const toggleError = localToggleErrors[row.id];
+
+                return (
+                    <Box
+                        onClick={(e) => e.stopPropagation()}
+                        sx={{ display: 'flex', alignItems: 'center', width: '100%', height: '100%', position: 'relative' }}
+                    >
+                        <Switch
+                            size="small"
+                            checked={!!row.isLocal}
+                            disabled={!canToggle || togglingLocalRowIds.has(row.id)}
+                            onChange={(e) => handleLocalToggle(row, e.target.checked)}
+                            title={row.isLocal ? 'Remove local status' : 'Mark as local'}
+                        />
+                        {toggleError && (
+                            <span
+                                title={toggleError}
+                                style={{
+                                    position: 'absolute',
+                                    left: 'calc(100% + 4px)',
+                                    top: '50%',
+                                    transform: 'translateY(-50%)',
+                                    fontSize: '11px',
+                                    lineHeight: 1,
+                                    color: '#7f1d1d',
+                                    background: 'rgba(254, 226, 226, 0.95)',
+                                    border: '1px solid rgba(248, 113, 113, 0.45)',
+                                    borderRadius: '9999px',
+                                    padding: '3px 6px',
+                                    whiteSpace: 'nowrap',
+                                    pointerEvents: 'none',
+                                    zIndex: 1,
+                                }}
+                            >
+                                Failed
+                            </span>
+                        )}
                     </Box>
                 );
             },

--- a/Web/web.client/src/components/BeaconHistoryModal.tsx
+++ b/Web/web.client/src/components/BeaconHistoryModal.tsx
@@ -50,9 +50,10 @@ interface BeaconHistoryModalProps {
     isAdmin?: boolean;
     isCustodian?: boolean;
     currentUserId?: number | null;
+    onMapPinLocalStatusChanged?: (mapPinId: number, isLocal: boolean) => void;
 }
 
-export function BeaconHistoryModal({ open, onClose, beaconID, beaconName, subdivisionID, railroad: _railroad, subdivision: _subdivision, theme, lastUpdate, trackedPins: propTrackedPins, hourFormat, canViewSupportAddresses = false, isAdmin = false, isCustodian = false, currentUserId = null }: BeaconHistoryModalProps) {
+export function BeaconHistoryModal({ open, onClose, beaconID, beaconName, subdivisionID, railroad: _railroad, subdivision: _subdivision, theme, lastUpdate, trackedPins: propTrackedPins, hourFormat, canViewSupportAddresses = false, isAdmin = false, isCustodian = false, currentUserId = null, onMapPinLocalStatusChanged }: BeaconHistoryModalProps) {
     const canManageLocalTrains = isAdmin || isCustodian;
     const [loading, setLoading] = useState(false);
     const [history, setHistory] = useState<MapPinHistory[]>([]);
@@ -194,6 +195,10 @@ export function BeaconHistoryModal({ open, onClose, beaconID, beaconName, subdiv
                 setLocalToggleErrors(prev => ({ ...prev, [row.id]: message }));
             } else {
                 setHistory(prev => prev.map(h => h.id === row.id ? { ...h, isLocal: result.data!.isLocal } : h));
+                // Patch the live map marker too - it's only otherwise refreshed by a fresh SignalR
+                // telemetry push, which may not arrive for a while for a stationary train.
+                const liveMapPinId = row.originalMapPinID ?? row.id;
+                onMapPinLocalStatusChanged?.(Number(liveMapPinId), result.data.isLocal);
             }
         } catch (err) {
             console.error('Failed to toggle local status:', err);
@@ -219,7 +224,7 @@ export function BeaconHistoryModal({ open, onClose, beaconID, beaconName, subdiv
                 delete localToggleFeedbackTimeoutsRef.current[row.id];
             }, 4000);
         }
-    }, [isAdmin, currentUserId]);
+    }, [isAdmin, currentUserId, onMapPinLocalStatusChanged]);
 
     const columns: GridColDef[] = [
         { field: 'id', headerName: 'ID', width: 70 },

--- a/Web/web.client/src/components/TelemetryMarker.tsx
+++ b/Web/web.client/src/components/TelemetryMarker.tsx
@@ -225,7 +225,7 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
         const trackingBadgeBorder = isTracked ? '1px solid rgba(0, 0, 0, 0.5)' : '1px solid rgba(0, 0, 0, 0.3)';
         const trackingBadgeTextColor = isTracked ? '#000' : '#666';
         const trackingBadge = `<span style='width:14px;height:14px;background-color:${trackingBadgeColor};border-radius:50%;border:${trackingBadgeBorder};display:inline-flex;align-items:center;justify-content:center;font-size:9px;font-weight:900;color:${trackingBadgeTextColor};line-height:14px;flex-shrink:0;'>T</span>`;
-        const showLocalStatus = canManageLocalTrains;
+        const showLocalStatus = canManageLocalTrains && pin.isLocal;
         const shareCodeLine = pin.shareCode
             ? `<span id='${trackTextId}' style='cursor:pointer;display:inline-flex;align-items:center;gap:6px;padding:${actionRowPadding};margin-bottom:${actionRowGap};'><span style='display:inline-flex;align-items:center;'>${trackingBadge}</span><span style='text-decoration:${isTracked ? 'underline' : 'none'};color:${isTracked ? (trackColor || '#FFD700') : 'inherit'};font-weight:${isTracked ? 700 : 400};'>${displayTrainLabel}</span></span><br/>`
             : '';
@@ -235,11 +235,9 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
         const trackText = isTracked
             ? 'Tracking'
             : 'Not Tracking';
-        const localStatusColor = pin.isLocal ? '#facc15' : '#9ca3af';
-        const localStatusLabel = pin.isLocal ? 'Local' : 'Not Local';
         const localStatusTextColor = mapTheme === 'dark' ? '#d1d5db' : '#6b7280';
         const localStatusMarkup = showLocalStatus
-            ? `<span style='display:inline-flex;align-items:center;gap:6px;padding:${actionRowPadding};margin-top:${isCoarsePointer ? '2px' : '0'};margin-bottom:6px;color:${localStatusTextColor};'><span style='width:14px;height:14px;background-color:${localStatusColor};border-radius:50%;border:1px solid rgba(0,0,0,0.4);display:inline-flex;align-items:center;justify-content:center;font-size:9px;font-weight:900;color:${pin.isLocal ? '#000' : '#4b5563'};line-height:14px;flex-shrink:0;'>L</span><span>${localStatusLabel}</span></span>`
+            ? `<span style='display:inline-flex;align-items:center;gap:6px;padding:${actionRowPadding};margin-top:${isCoarsePointer ? '2px' : '0'};margin-bottom:6px;color:${localStatusTextColor};'><span style='width:14px;height:14px;background-color:#facc15;border-radius:50%;border:1px solid rgba(0,0,0,0.4);display:inline-flex;align-items:center;justify-content:center;font-size:9px;font-weight:900;color:#000;line-height:14px;flex-shrink:0;'>L</span><span>Local</span></span>`
             : '';
 
         // Use only inline color for the track link, not for the popup background

--- a/Web/web.client/src/components/TelemetryMarker.tsx
+++ b/Web/web.client/src/components/TelemetryMarker.tsx
@@ -5,7 +5,6 @@ import { parseISO } from 'date-fns/parseISO';
 import { format } from 'date-fns';
 import { addTrackedMapPin, removeTrackedMapPin, getTrackedPinSymbol, updateTrackedPinSymbol, refreshTrackedPinsFromApi, copyTrackedPinShareUrl, buildTrackedPinShareUrl } from '../services/trackedPins';
 import { deleteMapPinAddresses } from '../api/mapPinsApi';
-import { toggleSubdivisionLocalTrainAddress } from '../api/subdivisions';
 // Extend window type for setTrackedPinsStateFromApi
 declare global {
     interface Window {
@@ -49,9 +48,7 @@ interface TelemetryMarkerProps {
     canViewSupportAddresses?: boolean;
     isAdmin?: boolean;
     canManageLocalTrains?: boolean;
-    currentUserId?: number | null;
     onMapPinDeleted?: (id: number) => void;
-    onMapPinLocalStatusChanged?: (id: number, isLocal: boolean) => void;
 }
 
 const formatDirection = (dir?: string | null): string => {
@@ -86,9 +83,7 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
     canViewSupportAddresses = false,
     isAdmin = false,
     canManageLocalTrains = false,
-    currentUserId = null,
     onMapPinDeleted,
-    onMapPinLocalStatusChanged,
 }) => {
     // hourFormat is destructured from props with default '24'
     // Inject dark mode popup CSS override once per page load
@@ -218,8 +213,6 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
         const shareTextId = `share-text-${pin.id}`;
         const shareStatusId = `share-status-${pin.id}`;
         const resetAddressesId = `reset-addresses-${pin.id}`;
-        const localToggleButtonId = `local-toggle-${pin.id}`;
-        const localToggleStatusId = `local-toggle-status-${pin.id}`;
         const trackedPinForLabel =
             trackedPins.find(tp => String(tp.id) === String(pin.id)) ||
             (pin.shareCode ? trackedPins.find(tp => tp.shareCode === pin.shareCode) : undefined);
@@ -232,15 +225,7 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
         const trackingBadgeBorder = isTracked ? '1px solid rgba(0, 0, 0, 0.5)' : '1px solid rgba(0, 0, 0, 0.3)';
         const trackingBadgeTextColor = isTracked ? '#000' : '#666';
         const trackingBadge = `<span style='width:14px;height:14px;background-color:${trackingBadgeColor};border-radius:50%;border:${trackingBadgeBorder};display:inline-flex;align-items:center;justify-content:center;font-size:9px;font-weight:900;color:${trackingBadgeTextColor};line-height:14px;flex-shrink:0;'>T</span>`;
-        const activeLocalAddress = Array.isArray(pin.addresses)
-            ? (pin.addresses.find(a => a.isActive) ?? pin.addresses[0])
-            : undefined;
-        const localAddressId = activeLocalAddress?.addressID;
-        const canToggleLocal =
-            canManageLocalTrains &&
-            Number.isInteger(localAddressId) &&
-            Number(localAddressId) > 0 &&
-            Number(pin.subdivisionID) > 0;
+        const showLocalStatus = canManageLocalTrains;
         const shareCodeLine = pin.shareCode
             ? `<span id='${trackTextId}' style='cursor:pointer;display:inline-flex;align-items:center;gap:6px;padding:${actionRowPadding};margin-bottom:${actionRowGap};'><span style='display:inline-flex;align-items:center;'>${trackingBadge}</span><span style='text-decoration:${isTracked ? 'underline' : 'none'};color:${isTracked ? (trackColor || '#FFD700') : 'inherit'};font-weight:${isTracked ? 700 : 400};'>${displayTrainLabel}</span></span><br/>`
             : '';
@@ -250,11 +235,11 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
         const trackText = isTracked
             ? 'Tracking'
             : 'Not Tracking';
-        const localButtonColor = pin.isLocal ? '#facc15' : '#9ca3af';
-        const localButtonText = pin.isLocal ? 'Local' : 'Mark Local';
+        const localStatusColor = pin.isLocal ? '#facc15' : '#9ca3af';
+        const localStatusLabel = pin.isLocal ? 'Local' : 'Not Local';
         const localStatusTextColor = mapTheme === 'dark' ? '#d1d5db' : '#6b7280';
-        const localToggleMarkup = canToggleLocal
-            ? `<button id='${localToggleButtonId}' type='button' title='${pin.isLocal ? 'Remove local status' : 'Mark as local'}' style='cursor:pointer;display:inline-flex;align-items:center;gap:6px;padding:${actionRowPadding};margin-top:${isCoarsePointer ? '2px' : '0'};margin-bottom:6px;color:${localStatusTextColor};background:none;border:none;font:inherit;text-align:left;line-height:inherit;'><span style='width:14px;height:14px;background-color:${localButtonColor};border-radius:50%;border:1px solid rgba(0,0,0,0.4);display:inline-flex;align-items:center;justify-content:center;font-size:9px;font-weight:900;color:${pin.isLocal ? '#000' : '#4b5563'};line-height:14px;flex-shrink:0;'>L</span><span style='text-decoration:underline;'>${localButtonText}</span><span id='${localToggleStatusId}' style='font-size:12px;opacity:0;transition:opacity 0.2s ease;'></span></button>`
+        const localStatusMarkup = showLocalStatus
+            ? `<span style='display:inline-flex;align-items:center;gap:6px;padding:${actionRowPadding};margin-top:${isCoarsePointer ? '2px' : '0'};margin-bottom:6px;color:${localStatusTextColor};'><span style='width:14px;height:14px;background-color:${localStatusColor};border-radius:50%;border:1px solid rgba(0,0,0,0.4);display:inline-flex;align-items:center;justify-content:center;font-size:9px;font-weight:900;color:${pin.isLocal ? '#000' : '#4b5563'};line-height:14px;flex-shrink:0;'>L</span><span>${localStatusLabel}</span></span>`
             : '';
 
         // Use only inline color for the track link, not for the popup background
@@ -278,7 +263,7 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
                 })()}<br/>
                 ${shareCodeLine}
                 ${addressLines}
-                ${localToggleMarkup}
+                ${localStatusMarkup}
                 ${pin.shareCode ? `<button id='${shareTextId}' type='button' title='Share link' style='cursor:pointer;display:flex;align-items:center;gap:6px;padding:${actionRowPadding};margin-top:${isCoarsePointer ? '2px' : '0'};margin-bottom:6px;color:${mapTheme === 'dark' ? '#d5d9df' : '#4b5563'};background:none;border:none;font:inherit;text-align:left;line-height:inherit;'>${copyIcon}<span style='text-decoration:underline;'>Share</span><span id='${shareStatusId}' style='font-size:12px;opacity:0;transition:opacity 0.2s ease;'></span></button>` : ''}
                 ${pin.shareCode ? '' : `<span id='${trackTextId}' style='cursor:pointer;text-decoration:underline;display:inline-flex;align-items:center;gap:6px;padding:${actionRowPadding};'><span style='display:inline-flex;align-items:center;'>${trackingBadge}</span>${trackText}</span>`}
                 ${isAdmin && canViewSupportAddresses ? `<br/><button id='${resetAddressesId}' type='button' title='Admin: clear address ID list' style='cursor:pointer;display:inline-flex;align-items:center;gap:6px;padding:${actionRowPadding};margin-top:4px;color:#ef4444;background:none;border:none;font:inherit;text-align:left;line-height:inherit;font-size:0.85em;'>&#x26A0; Reset Addresses</button>` : ''}
@@ -302,10 +287,8 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
         // Attach click handler to trackText in popup DOM on popupopen, and re-attach if popup content changes
         let trackTextEl: HTMLElement | null = null;
         let shareTextEl: HTMLElement | null = null;
-        let localToggleEl: HTMLElement | null = null;
         let observer: MutationObserver | null = null;
         let shareFeedbackTimeout: ReturnType<typeof setTimeout> | null = null;
-        let localToggleFeedbackTimeout: ReturnType<typeof setTimeout> | null = null;
         const updateShareStatus = (isSuccess: boolean) => {
             const shareStatusEl = document.getElementById(shareStatusId);
             if (!shareStatusEl) {
@@ -387,75 +370,6 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
                 updateShareStatus(false);
             }
         };
-        const updateLocalToggleStatus = (isSuccess: boolean, message?: string) => {
-            const localStatusEl = document.getElementById(localToggleStatusId);
-            if (!localStatusEl) {
-                return;
-            }
-
-            const badgePadding = isCoarsePointer ? '4px 8px' : '3px 6px';
-            if (isSuccess) {
-                localStatusEl.innerHTML = `<span style="display:inline-flex;align-items:center;gap:4px;color:#14532d;background:rgba(220,252,231,0.95);border:1px solid rgba(34,197,94,0.35);border-radius:9999px;padding:${badgePadding};line-height:1;white-space:nowrap;font-size:12px;pointer-events:none;">Updated</span>`;
-            } else {
-                const text = message ? message.replace(/</g, '&lt;').replace(/>/g, '&gt;') : 'Failed';
-                localStatusEl.innerHTML = `<span style="display:inline-flex;align-items:center;gap:4px;color:#7f1d1d;background:rgba(254,226,226,0.95);border:1px solid rgba(248,113,113,0.45);border-radius:9999px;padding:${badgePadding};line-height:1;white-space:nowrap;font-size:12px;pointer-events:none;">${text}</span>`;
-            }
-            localStatusEl.style.opacity = '1';
-
-            if (localToggleFeedbackTimeout) {
-                clearTimeout(localToggleFeedbackTimeout);
-            }
-
-            localToggleFeedbackTimeout = setTimeout(() => {
-                const currentLocalStatusEl = document.getElementById(localToggleStatusId);
-                if (!currentLocalStatusEl) {
-                    return;
-                }
-
-                currentLocalStatusEl.style.opacity = '0';
-                currentLocalStatusEl.textContent = '';
-            }, 3000);
-        };
-        const handleLocalToggleClick = async (e: MouseEvent) => {
-            e.preventDefault();
-            e.stopPropagation();
-            e.stopImmediatePropagation();
-
-            if (!canToggleLocal || !Number.isInteger(localAddressId)) {
-                return;
-            }
-
-            const target = document.getElementById(localToggleButtonId) as HTMLButtonElement | null;
-            if (target) {
-                target.disabled = true;
-                target.style.opacity = '0.7';
-            }
-
-            try {
-                const result = await toggleSubdivisionLocalTrainAddress(
-                    Number(pin.subdivisionID),
-                    Number(localAddressId),
-                    { isAdmin, currentUserId }
-                );
-
-                if (result.errors.length > 0 || !result.data) {
-                    const errorText = result.errors[0] || 'Failed';
-                    updateLocalToggleStatus(false, errorText.toLowerCase().includes('assigned subdivision') ? 'Forbidden' : 'Failed');
-                    return;
-                }
-
-                shouldReopenPopupRef.current = true;
-                onMapPinLocalStatusChanged?.(Number(pin.id), result.data.isLocal);
-                updateLocalToggleStatus(true);
-            } catch {
-                updateLocalToggleStatus(false);
-            } finally {
-                if (target) {
-                    target.disabled = false;
-                    target.style.opacity = '1';
-                }
-            }
-        };
         const handleResetAddressesClick = async (e: MouseEvent) => {
             e.preventDefault();
             e.stopPropagation();
@@ -484,13 +398,6 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
                 shareTextEl.addEventListener('click', handleShareTextClick);
             }
 
-            localToggleEl = document.getElementById(localToggleButtonId);
-            if (localToggleEl) {
-                L.DomEvent.disableClickPropagation(localToggleEl);
-                L.DomEvent.disableScrollPropagation(localToggleEl);
-                localToggleEl.addEventListener('click', handleLocalToggleClick);
-            }
-
             if (isAdmin && canViewSupportAddresses) {
                 const resetEl = document.getElementById(resetAddressesId);
                 if (resetEl) {
@@ -508,11 +415,6 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
             if (shareTextEl) {
                 shareTextEl.removeEventListener('click', handleShareTextClick);
                 shareTextEl = null;
-            }
-
-            if (localToggleEl) {
-                localToggleEl.removeEventListener('click', handleLocalToggleClick);
-                localToggleEl = null;
             }
 
             const resetEl = document.getElementById(resetAddressesId);
@@ -572,11 +474,8 @@ const TelemetryMarker: React.FC<TelemetryMarkerProps & { mapTheme: 'dark' | 'lig
             if (shareFeedbackTimeout) {
                 clearTimeout(shareFeedbackTimeout);
             }
-            if (localToggleFeedbackTimeout) {
-                clearTimeout(localToggleFeedbackTimeout);
-            }
         };
-    }, [pin.id, pin.shareCode, pin.beaconID, pin.beaconName, pin.railroad, pin.subdivision, pin.subdivisionID, pin.milepost, pin.direction, pin.moving, pin.isLocal, pin.lastUpdate, pin.addresses, isTracked, trackColor, mapTheme, hourFormat, isAdmin, canManageLocalTrains, currentUserId, canViewSupportAddresses, onMapPinDeleted, onMapPinLocalStatusChanged]);
+    }, [pin.id, pin.shareCode, pin.beaconID, pin.beaconName, pin.railroad, pin.subdivision, pin.subdivisionID, pin.milepost, pin.direction, pin.moving, pin.isLocal, pin.lastUpdate, pin.addresses, isTracked, trackColor, mapTheme, hourFormat, isAdmin, canManageLocalTrains, canViewSupportAddresses, onMapPinDeleted]);
 
     // Use ArrowMapPin as the icon, with rotation and border color
     const createCustomIcon = () => {

--- a/Web/web.client/src/components/TelemetryMarkers.tsx
+++ b/Web/web.client/src/components/TelemetryMarkers.tsx
@@ -17,9 +17,7 @@ interface TelemetryMarkersProps {
     canViewSupportAddresses?: boolean;
     isAdmin?: boolean;
     canManageLocalTrains?: boolean;
-    currentUserId?: number | null;
     onMapPinDeleted?: (id: number) => void;
-    onMapPinLocalStatusChanged?: (id: number, isLocal: boolean) => void;
 }
 
 const TelemetryMarkers: React.FC<TelemetryMarkersProps & { mapTheme: 'dark' | 'light' }> = ({
@@ -32,9 +30,7 @@ const TelemetryMarkers: React.FC<TelemetryMarkersProps & { mapTheme: 'dark' | 'l
     canViewSupportAddresses = false,
     isAdmin = false,
     canManageLocalTrains = false,
-    currentUserId = null,
     onMapPinDeleted,
-    onMapPinLocalStatusChanged,
 }) => {
     const size = getMarkerSize(zoom);
 
@@ -58,9 +54,7 @@ const TelemetryMarkers: React.FC<TelemetryMarkersProps & { mapTheme: 'dark' | 'l
                         canViewSupportAddresses={canViewSupportAddresses}
                         isAdmin={isAdmin}
                         canManageLocalTrains={canManageLocalTrains}
-                        currentUserId={currentUserId}
                         onMapPinDeleted={onMapPinDeleted}
-                        onMapPinLocalStatusChanged={onMapPinLocalStatusChanged}
                     />
                 ) : null
             )}

--- a/Web/web.client/src/views/RailMap.tsx
+++ b/Web/web.client/src/views/RailMap.tsx
@@ -1006,6 +1006,7 @@ const RailMap: React.FC = () => {
                 isAdmin={isAdmin}
                 isCustodian={isCustodian}
                 currentUserId={session?.userId ?? null}
+                onMapPinLocalStatusChanged={handleMapPinLocalStatusChanged}
             />
         </>
     );

--- a/Web/web.client/src/views/RailMap.tsx
+++ b/Web/web.client/src/views/RailMap.tsx
@@ -966,9 +966,7 @@ const RailMap: React.FC = () => {
                     canViewSupportAddresses={canViewSupportAddresses}
                     isAdmin={isAdmin}
                     canManageLocalTrains={isAdmin || isCustodian}
-                    currentUserId={session?.userId ?? null}
                     onMapPinDeleted={handleMapPinDeleted}
-                    onMapPinLocalStatusChanged={handleMapPinLocalStatusChanged}
                 />}
 
                 {beaconsLoaded && (

--- a/Web/web.client/src/views/RailMap.tsx
+++ b/Web/web.client/src/views/RailMap.tsx
@@ -1003,6 +1003,9 @@ const RailMap: React.FC = () => {
                 trackedPins={trackedPinsState}
                 hourFormat={hourFormat}
                 canViewSupportAddresses={canViewSupportAddresses}
+                isAdmin={isAdmin}
+                isCustodian={isCustodian}
+                currentUserId={session?.userId ?? null}
             />
         </>
     );


### PR DESCRIPTION
## Summary

Closes #71

- Adds a Local toggle switch to the beacon history flyout's (`BeaconHistoryModal.tsx`) `DataGrid`, in the column between "Train" and "Share". Visible only to Admins/Custodians. Toggling calls the same `toggleSubdivisionLocalTrainAddress` used by the map pin pop-up, targeting the row's subdivision and primary (first) address, and updates the row's badge in place immediately.
- Direction column now shows compass abbreviations (`NW`) instead of full words (`Northwest`) to make room for the new column.
- **Bug fix found in integration testing:** the toggle would silently revert a few seconds after a successful flip. `MapPinHistory.IsLocal` is a snapshot written by telemetry ingestion, so it went stale as soon as a subdivision's local-train list changed, and the flyout's periodic refetch overwrote the optimistic UI state with that stale value. `GetHistoryByBeaconIdAsync` now recomputes `IsLocal` from the subdivision's current settings at read time, same as `MapPinService` already does for live map pins (shared via a new `LocalTrainEvaluator`).
- **Bug fix found in integration testing:** the live map marker didn't reflect the change. `mapPins` is only patched by SignalR pushes tied to fresh telemetry, not polling, so `BeaconHistoryModal` now takes an `onMapPinLocalStatusChanged` callback and calls it after a successful toggle, wired to the same handler the map pin pop-up already used.
- **Follow-up cleanup (per review feedback):** removed the click-ability from the map pin pop-up's "(L) Local" link now that the flyout has its own toggle — it's now a plain, non-interactive "Local" badge shown only for local trains (nothing shown for non-local trains).

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 182/182 backend tests pass (10 new: `LocalTrainEvaluatorTests`, `MapPinHistoryServiceTests`)
- [x] `tsc --noEmit` — clean
- [x] `eslint` — clean (only pre-existing warnings unrelated to this change)
- [x] `vitest` — 59/59 frontend tests pass (15 new in `BeaconHistoryModal.test.ts`)
- [ ] Manual verification in the flyout as Admin/Custodian: toggle Local on/off, confirm the badge updates, holds (no revert), and the live map marker updates
- [ ] Manual verification as a Custodian of a different subdivision and as a Viewer: confirm the switch is not shown
- [ ] Manual check of the Direction column across all 8 compass values

🤖 Generated with [Claude Code](https://claude.com/claude-code)