### PR TITLE
Migrate C# projects to .NET 10

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 env:
-  DOTNET_VERSION: 8.0.x
+  DOTNET_VERSION: 10.0.x
   NODE_VERSION: 20.x
   WEB_PROJECT: Web/Web.Server/Web.Server.csproj
   BETA_PUBLISH_PROFILE: Web/Web.Server/Properties/PublishProfiles/BETA.pubxml

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 env:
-  DOTNET_VERSION: 8.0.x
+  DOTNET_VERSION: 10.0.x
   NODE_VERSION: 20.x
   WEB_PROJECT: Web/Web.Server/Web.Server.csproj
   PRODUCTION_PUBLISH_PROFILE: Web/Web.Server/Properties/PublishProfiles/PRODUCTION.pubxml

--- a/ConsoleApp/ConsoleApp.csproj
+++ b/ConsoleApp/ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/Services.UnitTests/Services.UnitTests.csproj
+++ b/Services.UnitTests/Services.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/Services/Services.csproj
+++ b/Services/Services.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Web/Web.Server.IntegrationTests/Web.Server.IntegrationTests.csproj
+++ b/Web/Web.Server.IntegrationTests/Web.Server.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Web/Web.Server/Properties/PublishProfiles/BETA.pubxml
+++ b/Web/Web.Server/Properties/PublishProfiles/BETA.pubxml
@@ -19,7 +19,7 @@
     <EnableMsDeployAppOffline>true</EnableMsDeployAppOffline>
     <EnvironmentName>Beta</EnvironmentName>
     <_TargetId>IISWebDeploy</_TargetId>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <UserName>toddtayl</UserName>
     <_SavePWD>true</_SavePWD>
   </PropertyGroup>

--- a/Web/Web.Server/Properties/PublishProfiles/PRODUCTION.pubxml
+++ b/Web/Web.Server/Properties/PublishProfiles/PRODUCTION.pubxml
@@ -19,7 +19,7 @@
     <EnableMsDeployAppOffline>true</EnableMsDeployAppOffline>
     <EnvironmentName>Production</EnvironmentName>
     <_TargetId>IISWebDeploy</_TargetId>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <UserName>toddtayl</UserName>
     <_SavePWD>true</_SavePWD>
   </PropertyGroup>

--- a/Web/Web.Server/Web.Server.csproj
+++ b/Web/Web.Server/Web.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<SpaRoot>..\web.client\</SpaRoot>
@@ -22,10 +22,7 @@
 		<PackageReference Include="Mapster.DependencyInjection" Version="1.0.1" />
 		<PackageReference Include="Mailtrap" Version="3.0.0" />
 		<PackageReference Include="Mailtrap.Abstractions" Version="3.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Http.Connections" Version="1.2.0" />
-		<PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.0" />
 		<PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="9.0.4" Condition="'$(Configuration)' == 'Debug'" />
-		<PackageReference Include="Microsoft.Build" Version="17.8.43" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">
 			<PrivateAssets>all</PrivateAssets>
@@ -38,7 +35,6 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="NetMQ" Version="4.0.2.2" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Serilog" Version="4.2.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />

--- a/Web/Web.ServerTests/Web.Server.Tests.csproj
+++ b/Web/Web.ServerTests/Web.Server.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -9,10 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Mapster.DependencyInjection" Version="1.0.1" />
-    <PackageReference Include="CloneExtensions" Version="1.4.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Moq.EntityFrameworkCore" Version="9.0.0.5" />
     <PackageReference Include="MSTest" Version="3.8.3" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Upgrade all six C# project TFMs from `net9.0` to `net10.0` (ConsoleApp, Services, Services.UnitTests, Web.Server, Web.Server.Tests, Web.Server.IntegrationTests)
- Remove NuGet packages with no references anywhere in the codebase: `NetMQ`, `Microsoft.Build`, `CloneExtensions`, `Moq.EntityFrameworkCore`
- Remove `Microsoft.AspNetCore.Http.Connections` and `Microsoft.AspNetCore.SignalR` explicit package references — SignalR functionality (used via `NotificationHub`) is now supplied by the ASP.NET Core shared framework on .NET 10; NuGet's `NU1510` analysis flagged both as unnecessary

## Test plan
- [x] `dotnet build RugbyJunctionTrainTracker.sln` — 0 errors
- [x] `dotnet build Web/Web.sln` — 0 errors
- [x] `dotnet build Web/Web.Server.IntegrationTests/Web.Server.IntegrationTests.csproj` — 0 errors
- [x] `dotnet test RugbyJunctionTrainTracker.sln` — all tests pass (Services.UnitTests: 8/8, Web.Server.Tests: 181/182, 1 pre-existing skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)