### PR TITLE
Replace Carto map tiles with OpenStreetMap

### DIFF
--- a/Web/web.client/src/index.css
+++ b/Web/web.client/src/index.css
@@ -190,6 +190,15 @@ body:has(.admin-layout) .app-footer {
   background: #181818; /* match dark theme if needed */
 }
 
+/* OSM tiles have no built-in dark style; fake one with a CSS filter
+   since the free Carto dark_all/light_all tiles now require a paid API key.
+   Grayscale first removes OSM's land-use colors (parks/water/etc.) so the
+   invert produces a clean monochrome basemap instead of tinted colors that
+   compete with the blue track overlay. */
+.map-theme-dark .leaflet-tile-pane {
+  filter: grayscale(1) invert(1) brightness(0.9) contrast(1.1);
+}
+
 /* ---------- Marker Z-Index ---------- */
 .beacon-marker-z {
   z-index: 400;

--- a/Web/web.client/src/views/RailMap.tsx
+++ b/Web/web.client/src/views/RailMap.tsx
@@ -39,9 +39,8 @@ const ICON_CACHE_BUSTER = import.meta.env.VITE_APP_VERSION
     ? `?v=${import.meta.env.VITE_APP_VERSION}`
     : '';
 
-const DARK_TILE_URL = "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png";
-const LIGHT_TILE_URL = "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png";
-const TILE_ATTRIBUTION = '&copy; <a href="https://carto.com/">CARTO</a>';
+const TILE_URL = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png";
+const TILE_ATTRIBUTION = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 
 const fallbackCenter: LatLngTuple = [44.524570, -89.567290]; // Default if location fails
 const MILEPOST_LABEL_MIN_ZOOM = 12;
@@ -744,6 +743,15 @@ const RailMap: React.FC = () => {
         }
     }, [mapTheme]);
 
+    // MapContainer's className prop is only applied at mount (react-leaflet
+    // freezes it in state), so toggle the tile-darkening class directly on the
+    // Leaflet container element whenever the theme changes.
+    useEffect(() => {
+        const container = mapRef.current?.getContainer();
+        if (!container) return;
+        container.classList.toggle('map-theme-dark', mapTheme === 'dark');
+    }, [mapTheme]);
+
     const handleToggleTheme = () => {
         setMapTheme(prev => {
             const next = prev === 'dark' ? 'light' : 'dark';
@@ -895,7 +903,7 @@ const RailMap: React.FC = () => {
             >
                 <MapZoomListener />
                 <TileLayer
-                    url={mapTheme === 'dark' ? DARK_TILE_URL : LIGHT_TILE_URL}
+                    url={TILE_URL}
                     attribution={TILE_ATTRIBUTION}
                 />
 


### PR DESCRIPTION
## Summary
- Carto dropped its free API-key tier for basemap tiles, so the map was rendering with an "API KEY REQUIRED" watermark over every tile.
- Switched to OpenStreetMap's free, no-key tile service.
- Since OSM only ships one (light, full-color) tile style, dark mode is now faked with a CSS `grayscale + invert` filter on the tile pane, which also removes OSM's land-use colors so the blue track overlay reads clearly.
- Fixed a related bug where the dark/light toggle stopped affecting map tiles after the initial page load: `MapContainer`'s `className` prop is frozen at mount by react-leaflet, so the theme class is now applied via a `useEffect` on the live Leaflet container instead.

## Test plan
- [x] `tsc -b --noEmit` passes
- [x] Verified `tile.openstreetmap.org` responds 200 with no API key
- [x] Manually confirmed in dev server: dark mode shows monochrome dark tiles, light mode shows normal OSM tiles, and toggling between them updates the tiles live
- [ ] Reviewer: spot-check map at a few zoom levels for tile load/attribution correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)