### PR TITLE
Grayscale light mode map tiles

### DIFF
--- a/Web/web.client/src/index.css
+++ b/Web/web.client/src/index.css
@@ -199,6 +199,12 @@ body:has(.admin-layout) .app-footer {
   filter: grayscale(1) invert(1) brightness(0.9) contrast(1.1);
 }
 
+/* Light mode: grayscale only (no invert) so land-use colors don't compete
+   with the blue track overlay, while tiles stay light. */
+.leaflet-container:not(.map-theme-dark) .leaflet-tile-pane {
+  filter: grayscale(1);
+}
+
 /* ---------- Marker Z-Index ---------- */
 .beacon-marker-z {
   z-index: 400;


### PR DESCRIPTION
## Summary
- Light mode OSM tiles render in full color, and land-use colors (parks, water, etc.) compete visually with the blue track overlay, similar to the issue previously fixed for dark mode in #77.
- Applies a grayscale-only filter (no invert, so tiles stay light) scoped to `.leaflet-container:not(.map-theme-dark) .leaflet-tile-pane`, matching the treatment already used for dark mode tiles.

## Test plan
- [x] `tsc -b --noEmit` passes
- [ ] Reviewer: toggle between light/dark mode in the running app and confirm light mode tiles are grayscale (not inverted) and dark mode is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)