### PR TITLE
Fix dark mode map tiles not applying on initial page load

### DIFF
--- a/Web/web.client/src/views/RailMap.tsx
+++ b/Web/web.client/src/views/RailMap.tsx
@@ -86,6 +86,7 @@ const RailMap: React.FC = () => {
     const [mapZoom, setMapZoom] = useState<number>(savedMapState?.zoom || 7);
     const [mapCenter, setMapCenter] = useState<LatLngTuple>(savedMapState?.center || fallbackCenter);
     const [mapTheme, setMapTheme] = useState(() => localStorage.getItem('mapTheme') || 'dark');
+    const [mapReady, setMapReady] = useState(false);
     const [hourFormat, setHourFormat] = useState(() => localStorage.getItem('hourFormat') || '24');
     const [milepostLayerVisible, setMilepostLayerVisible] = useState(() => {
         const saved = localStorage.getItem('milepostLayerVisible');
@@ -745,12 +746,17 @@ const RailMap: React.FC = () => {
 
     // MapContainer's className prop is only applied at mount (react-leaflet
     // freezes it in state), so toggle the tile-darkening class directly on the
-    // Leaflet container element whenever the theme changes.
+    // Leaflet container element whenever the theme changes. mapRef.current isn't
+    // populated until Leaflet's map instance is ready (one render after mount),
+    // so also re-run once mapReady flips true (set via MapContainer's whenReady
+    // prop below) rather than only on [mapTheme] — otherwise the very first
+    // mount is missed and the tile filter never applies until the user
+    // manually toggles the theme.
     useEffect(() => {
         const container = mapRef.current?.getContainer();
         if (!container) return;
         container.classList.toggle('map-theme-dark', mapTheme === 'dark');
-    }, [mapTheme]);
+    }, [mapTheme, mapReady]);
 
     const handleToggleTheme = () => {
         setMapTheme(prev => {
@@ -900,6 +906,7 @@ const RailMap: React.FC = () => {
                 style={{ height: historyModalOpen ? '60vh' : '100%', width: '100%', transition: 'height 0.3s' }}
                 scrollWheelZoom={true}
                 ref={mapRef}
+                whenReady={() => setMapReady(true)}
             >
                 <MapZoomListener />
                 <TileLayer


### PR DESCRIPTION
## Summary
- Bug: even with dark mode as the default theme, the map tiles rendered in light-mode colors on a fresh page load / browser restart, and only corrected once the user manually toggled the theme.
- Root cause: the effect that toggles the `map-theme-dark` class on the Leaflet container ran only on `[mapTheme]`. `mapRef.current` (and thus the container) isn't populated until react-leaflet's `MapContainer` finishes its own internal ready sequence — one render after mount — so on first load the effect fired too early, found no container, and no-opped. Since `mapTheme` doesn't change again until the user toggles it, the class was never applied until then.
- Fix: track map readiness via `MapContainer`'s `whenReady` prop (`mapReady` state) and include it as an effect dependency, so the class-toggle effect re-runs once the map container actually exists.

## Test plan
- [x] `tsc -b --noEmit` passes
- [ ] Reviewer: clear localStorage (or use a private window) and load the site fresh — map tiles should render in dark/monochrome style immediately, without needing to toggle the theme
- [ ] Reviewer: toggle theme back and forth to confirm no regression there

🤖 Generated with [Claude Code](https://claude.com/claude-code)